### PR TITLE
Query filters visibility

### DIFF
--- a/src/js/constants/field.js
+++ b/src/js/constants/field.js
@@ -1,5 +1,6 @@
 import common from './common.js'
 import fieldsProperties from './fieldsProperties.json'
+import utils from '@/js/utils'
 
 const attrs = common.attributes
 
@@ -226,30 +227,33 @@ Field.prototype.getError = function(document, locale) {
     return null
 }
 
+Field.prototype.isVisibleForActivities = function(activities){
+
+    var result = true
+
+    if (this.activities && activities) {
+        result = utils.intersectionIsNotNull(this.activities, activities)
+    }
+
+    return result
+}
+
 Field.prototype.isVisibleFor = function(document) {
     if (!this.extraIsVisibleFor(document)) {
         return false
     }
 
-    var result = true
-
-    const intersectionIsNotNull = function(arrayA, arrayB) {
-        for (let itemA of arrayA) {
-            if (arrayB.includes(itemA)) {
-                return true
-            }
-        }
-
+    if (!this.isVisibleForActivities(document.activities)) {
         return false
     }
 
-    if (this.activities && document.activities) {
-        result = intersectionIsNotNull(this.activities, document.activities)
-    } else if (this.waypoint_types) {
+    var result = true
+
+    if (this.waypoint_types) {
         if (document.waypoint_type) {
             result = this.waypoint_types.includes(document.waypoint_type)
         } else if (document.waypoint_types) {
-            result = intersectionIsNotNull(this.waypoint_types, document.waypoint_types)
+            result = utils.intersectionIsNotNull(this.waypoint_types, document.waypoint_types)
         } else {
             result = false
         }

--- a/src/js/constants/field.js
+++ b/src/js/constants/field.js
@@ -227,8 +227,7 @@ Field.prototype.getError = function(document, locale) {
     return null
 }
 
-Field.prototype.isVisibleForActivities = function(activities){
-
+Field.prototype.isVisibleForActivities = function(activities) {
     var result = true
 
     if (this.activities && activities) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -37,5 +37,16 @@ export default {
         const blob = new Blob([content], { type: fileType })
 
         saveAs(blob, fileName)
+    },
+
+    // does the intersection of two arrays is empty ?
+    intersectionIsNotNull(arrayA, arrayB) {
+        for (let itemA of arrayA) {
+            if (arrayB.includes(itemA)) {
+                return true
+            }
+        }
+
+        return false
     }
 }

--- a/src/views/documents/utils/QueryItems.vue
+++ b/src/views/documents/utils/QueryItems.vue
@@ -199,12 +199,6 @@
             categorizedFields() {
                 var result = []
 
-                // fake doc build from URL filter
-                var documentFromUrlFilter = {
-                    activities: this.urlActivities,
-                    waypoint_types: this.urlWaypoint_types
-                }
-
                 for (let category of Object.keys(categorizedFields[this.documentType])) {
                     let temp = {
                         name: category,
@@ -223,7 +217,7 @@
                                 temp.activeCount += 1
                             }
 
-                            if (field.isVisibleFor(documentFromUrlFilter)) {
+                            if (field.isVisibleForActivities(this.urlActivities)) {
                                 temp.fields.push(field)
                             }
                         }


### PR DESCRIPTION
Quoting bubu : 

> Dans le filtre des sorties, quand on sélectionne l'activité escalade, les filtres de cotations sont accessibles. Mais il n'y a que la cotation libre, alors qu'il faudrait aussi la cotation globale et la cotation équipement.