### PR TITLE
Allow devlopper to specify context messages for translations

### DIFF
--- a/src/translations/dist/fr.json
+++ b/src/translations/dist/fr.json
@@ -412,6 +412,9 @@
     "mixed_rating": "Cotation mixte",
     "Mobile application": "Application mobile",
     "modifications": "Conséquences sur les pratiques",
+    "Modified the": {
+      "modification date": "Modifié le"
+    },
     "mollasse_calcaire": "molasse",
     "More info": "Plus d'information",
     "more_than_3m": "supérieur à 3 mois",
@@ -532,8 +535,13 @@
     "public_transportation_rating": "Accessibilité en transports en commun",
     "public_transportation_types": "Type de transport en commun",
     "publication_date": "Date de publication",
-    "quality": "Complétude",
-    "quantity": "quantité",
+    "quality": {
+      "snow": "qualité",
+      "$$noContext": "Complétude"
+    },
+    "quantity": {
+      "snow": "quantité"
+    },
     "quartzite": "quartzite",
     "quiet": "non fréquenté",
     "raid": "raid",

--- a/src/translations/po/c2corg_ui-client.pot
+++ b/src/translations/po/c2corg_ui-client.pot
@@ -2046,6 +2046,7 @@ msgid "modifications"
 msgstr ""
 
 #: src/views/wiki/WhatsNewView.vue:7
+msgctxt "modification date"
 msgid "Modified the"
 msgstr ""
 
@@ -2602,14 +2603,19 @@ msgstr ""
 msgid "publication_date"
 msgstr ""
 
+#: src/views/wiki/edition/OutingEditionView.vue:97
+msgctxt "snow"
+msgid "quality"
+msgstr ""
+
 #: src/components/generics/markers/MarkerQuality.vue:2
 #: src/translations/fixed_strings_common_js.vue:146
-#: src/views/wiki/edition/OutingEditionView.vue:97
 #: src/views/wiki/edition/utils/QualityInputRow.vue:2
 msgid "quality"
 msgstr ""
 
 #: src/views/wiki/edition/OutingEditionView.vue:96
+msgctxt "snow"
 msgid "quantity"
 msgstr ""
 

--- a/src/views/wiki/WhatsNewView.vue
+++ b/src/views/wiki/WhatsNewView.vue
@@ -4,7 +4,7 @@
 
         <table>
             <tr>
-                <th v-translate>Modified the</th>
+                <th v-translate translate-context="modification date">Modified the</th>
                 <th v-translate>Author</th>
                 <th v-translate>Links</th>
                 <th/>

--- a/src/views/wiki/edition/OutingEditionView.vue
+++ b/src/views/wiki/edition/OutingEditionView.vue
@@ -93,8 +93,8 @@
                 <form-input-row :document="document" :field="fields.elevation_down_snow"/>
 
                 <form-row :label="$gettext('Snow')" is-grouped>
-                    <form-input :document="document" :field="fields.snow_quantity" :prefix="$gettext('quantity')"/>
-                    <form-input :document="document" :field="fields.snow_quality" :prefix="$gettext('quality')"/>
+                    <form-input :document="document" :field="fields.snow_quantity" :prefix="$gettext('quantity', 'snow')"/>
+                    <form-input :document="document" :field="fields.snow_quality" :prefix="$gettext('quality', 'snow')"/>
                 </form-row>
 
                 <form-input-row :document="document" :field="fields.conditions" :placeholder="$gettext('describe conditions')"/>

--- a/tools/extract-messages.js
+++ b/tools/extract-messages.js
@@ -7,6 +7,7 @@ https://www.gnu.org/software/gettext/manual/gettext.html
 Supported patterns in .vue and .js files :
 
     $gettext('msgid')
+    $gettext('msgid', 'msgctx')
 
 Supported pattern in .vue file, inside <template /> part :
 
@@ -94,7 +95,7 @@ Process.prototype.parseScript = function(file, data, regex) {
         while ((msgData = regex.exec(lines[i])) !== null) {
 
             let msgid = msgData[1]
-            let msgctxt = undefined
+            let msgctxt = msgData[2]
 
             this.push(`${file}:` + (i+1), msgctxt, msgid)
         }
@@ -131,6 +132,12 @@ Process.prototype.parseTemplate = function(file, data) {
 
         if (node.children[0].type !== NODETYPE_TEXT) {
             throw new Error(`In ${position}\nInterploation is not yet supported. Please use $gettext`)
+        }
+
+        for(let attribute of node.attrsList){
+            if(attribute.name==='translate-context') {
+                msgctxt = attribute.value
+            }
         }
 
         let msgid = node.children[0].text


### PR DESCRIPTION
Allow dev to specify context for translations. For instance, "quality" means document quality in C2C, translated into "complétude" in french.

But int's also used as snow quality in one single place, which is different in french, and must be translated in "qualité".

context can be specified with two way : 

* a second argument in `$gettext()` function
* a `translate-context` attribute on node containing `v-translate` directive 