### PR TITLE
fixe flex problem when printing from firefox

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
     <div v-if="alternativeSideMenu" class="alternative-side-menu-shader" @click="alternativeSideMenu=false"/>
 
     <!-- keep router view in last  -->
-    <div class="page-content">
+    <div class="page-content is-block-print">
       <router-view class="router-view"/>
     </div>
   </div>

--- a/src/assets/sass/helpers.scss
+++ b/src/assets/sass/helpers.scss
@@ -51,6 +51,10 @@
 
 @media print {
     /* print styles go here */
+
+    /* Printing from Firefox with content display:flex will print only the first page.
+    https://bugzilla.mozilla.org/show_bug.cgi?id=1241323
+    */
     .is-block-print {
         display:block !important;
     }

--- a/src/assets/sass/helpers.scss
+++ b/src/assets/sass/helpers.scss
@@ -51,6 +51,10 @@
 
 @media print {
     /* print styles go here */
+    .is-block-print {
+        display:block !important;
+    }
+
     .no-print {
         display: none!important;
     }
@@ -68,4 +72,5 @@
     .is-12-print{
         width: 100%!important;
     }
+
 }

--- a/src/views/document/ArticleView.vue
+++ b/src/views/document/ArticleView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns">
-      <div class="column is-3">
+    <div v-if="document" class="columns is-block-print">
+      <div class="column is-3 is-12-print">
         <div class="box">
           <field-view :document="document" :field="fields.activities" />
           <field-view :document="document" :field="fields.categories" />
@@ -12,7 +12,7 @@
 
         <tool-box :document="document"/>
       </div>
-      <div class="column is-9">
+      <div class="column is-9 is-12-print">
         <div class="box">
           <markdown-section :document="document" :field="fields.summary"/>
           <markdown-section :document="document" :field="fields.description" hide-title/>

--- a/src/views/document/BookView.vue
+++ b/src/views/document/BookView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns">
+    <div v-if="document" class="columns is-block-print">
       <div class="column is-3">
         <div class="box">
           <label-value :label="$gettext('activities')">

--- a/src/views/document/OutingView.vue
+++ b/src/views/document/OutingView.vue
@@ -11,7 +11,7 @@
         <tool-box :document="document"/>
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div class="column is-9 is-12-print is-block-print">
 
         <div class="box">
 

--- a/src/views/document/OutingView.vue
+++ b/src/views/document/OutingView.vue
@@ -4,14 +4,14 @@
 
     <images-box v-if="document" :document="document"/>
 
-    <div v-if="document" class="columns is-multiline">
+    <div v-if="document" class="columns is-multiline is-block-print">
 
       <div class="column is-3 no-print">
         <map-box :document="document"/>
         <tool-box :document="document"/>
       </div>
 
-      <div class="column is-9 is-12-print is-block-print">
+      <div class="column is-9 is-12-print">
 
         <div class="box">
 

--- a/src/views/document/RouteView.vue
+++ b/src/views/document/RouteView.vue
@@ -2,14 +2,14 @@
   <div class="section has-background-white-print">
 
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns">
+    <div v-if="document" class="columns is-block-print">
 
       <div class="column is-3 no-print">
         <map-box :document="document" @has-protection-area="hasProtectionArea=true"/>
         <tool-box :document="document"/>
       </div>
 
-      <div class="column is-9 is-12-print is-block-print">
+      <div class="column is-9 is-12-print">
         <!--   CONTENT  -->
 
         <div class="box">

--- a/src/views/document/RouteView.vue
+++ b/src/views/document/RouteView.vue
@@ -9,7 +9,7 @@
         <tool-box :document="document"/>
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div class="column is-9 is-12-print is-block-print">
         <!--   CONTENT  -->
 
         <div class="box">

--- a/src/views/document/XreportView.vue
+++ b/src/views/document/XreportView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns">
-      <div class="column is-3">
+    <div v-if="document" class="columns is-block-print">
+      <div class="column is-3 is-12-print">
 
         <div class="box">
 
@@ -34,7 +34,7 @@
         <tool-box :document="document"/>
       </div>
 
-      <div class="column is-9">
+      <div class="column is-9 is-12-print">
         <div class="box">
           <markdown-section :document="document" :field="fields.summary"/>
           <markdown-section :document="document" :field="fields.description"/>


### PR DESCRIPTION
Firefox is printing only the first page of a document if the document is displayed "flex".
This bug is reported several times : 
https://bugzilla.mozilla.org/show_bug.cgi?id=1241323
https://bugzilla.mozilla.org/show_bug.cgi?id=1421637 and more.

Also modify some view to display the column on 100% width.