### PR TITLE
Hide svg and print text for the orientations

### DIFF
--- a/src/components/generics/inputs/InputOrientation.vue
+++ b/src/components/generics/inputs/InputOrientation.vue
@@ -1,5 +1,14 @@
 <template>
-  <div class="control">
+  <div
+    class="control"
+    :title="((value_.indexOf('E')>-1)?'E ':'')
+            +((value_.indexOf('W')>-1)?'W ':'')
+            +((value_.indexOf('S')>-1)?'S ':'')
+            +((value_.indexOf('N')>-1)?'N ':'')
+            +((value_.indexOf('SE')>-1)?'SE ':'')
+            +((value_.indexOf('SW')>-1)?'SW ':'')
+            +((value_.indexOf('NE')>-1)?'NE ':'')
+            +((value_.indexOf('NW')>-1)?'NW':'')">
     <svg
       :class="{'is-read-only':disabled}"
       class="input-orientation is-unselectable"
@@ -83,8 +92,18 @@
 
 @media print{
   .input-orientation{
-    width:50px;
-    height:50px;
+    display:none;
+    /*width:50px;
+    height:50px;*/
+  }
+
+  div:before{
+    content:"Orientation : ";
+    font-weight: 700;
+  }
+
+  div:after{
+    content:attr(title);
   }
 }
 

--- a/src/components/generics/inputs/InputOrientation.vue
+++ b/src/components/generics/inputs/InputOrientation.vue
@@ -1,14 +1,5 @@
 <template>
-  <div
-    class="control"
-    :title="((value_.indexOf('E')>-1)?'E ':'')
-            +((value_.indexOf('W')>-1)?'W ':'')
-            +((value_.indexOf('S')>-1)?'S ':'')
-            +((value_.indexOf('N')>-1)?'N ':'')
-            +((value_.indexOf('SE')>-1)?'SE ':'')
-            +((value_.indexOf('SW')>-1)?'SW ':'')
-            +((value_.indexOf('NE')>-1)?'NE ':'')
-            +((value_.indexOf('NW')>-1)?'NW':'')">
+  <div class="control" :title="value_.join(', ')">
     <svg
       :class="{'is-read-only':disabled}"
       class="input-orientation is-unselectable"
@@ -93,12 +84,10 @@
 @media print{
   .input-orientation{
     display:none;
-    /*width:50px;
-    height:50px;*/
   }
 
   div:before{
-    content:"Orientation : ";
+    content:"Orientations : ";
     font-weight: 700;
   }
 


### PR DESCRIPTION
To save place on printed topo, we remove the svg representing the wind rose and write the different orientations in plain text.
Don't know if it's the best way to do it...