### PR TITLE
Mobile cards optimisation

### DIFF
--- a/src/components/cards/FeedCard.vue
+++ b/src/components/cards/FeedCard.vue
@@ -13,11 +13,11 @@
 
     <card-row>
       <document-title :document="item.document" class="is-ellipsed has-text-weight-bold" />
-      <span v-if="documentType=='outing'" class="is-nowrap">{{ dates }}</span>
+      <span v-if="documentType=='outing'" class="is-nowrap has-mobile-left-margin">{{ dates }}</span>
     </card-row>
 
     <card-row v-if="locale && locale.summary">
-      <p class="is-ellipsed">{{ locale.summary }}</p>
+      <p class="is-ellipsed is-mobile-max-3-lines-height">{{ locale.summary | stripMarkdown | max300chars }}</p>
     </card-row>
 
     <card-row v-if="images.length!=0">
@@ -82,6 +82,15 @@
 
     components: {
       Gallery
+    },
+
+    filters: {
+      max300chars(value) {
+        if (value.length > 300) {
+          return value.substring(0, 100) + '…';
+        }
+        return value;
+      }
     },
 
     mixins: [
@@ -167,6 +176,15 @@
     .feed-card{
       border-left:0!important;
       border-right:0!important;
+    }
+    .is-mobile-max-3-lines-height {
+      // proprietary stuff, supported on limited browsers
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+    }
+    .has-mobile-left-margin {
+      margin-left: 5px;
     }
   }
 

--- a/src/components/cards/FeedCard.vue
+++ b/src/components/cards/FeedCard.vue
@@ -78,19 +78,14 @@
   import Gallery from '@/components/gallery/Gallery';
   import { cardMixin } from './utils/mixins.js';
 
-  export default{
+  export default {
 
     components: {
       Gallery
     },
 
     filters: {
-      max300chars(value) {
-        if (value.length > 300) {
-          return value.substring(0, 100) + '…';
-        }
-        return value;
-      }
+      max300chars: value => value.length > 300 ? value.substring(0, 300) + '…' : value
     },
 
     mixins: [

--- a/src/components/cards/FeedCard.vue
+++ b/src/components/cards/FeedCard.vue
@@ -13,11 +13,11 @@
 
     <card-row>
       <document-title :document="item.document" class="is-ellipsed has-text-weight-bold" />
-      <span v-if="documentType=='outing'" class="is-nowrap has-mobile-left-margin">{{ dates }}</span>
+      <span v-if="documentType=='outing'" class="is-nowrap has-left-margin-mobile">{{ dates }}</span>
     </card-row>
 
     <card-row v-if="locale && locale.summary">
-      <p class="is-ellipsed is-mobile-max-3-lines-height">{{ locale.summary | stripMarkdown | max300chars }}</p>
+      <p class="is-ellipsed is-max-3-lines-height-mobile">{{ locale.summary | stripMarkdown | max300chars }}</p>
     </card-row>
 
     <card-row v-if="images.length!=0">
@@ -177,13 +177,13 @@
       border-left:0!important;
       border-right:0!important;
     }
-    .is-mobile-max-3-lines-height {
+    .is-max-3-lines-height-mobile {
       // proprietary stuff, supported on limited browsers
       display: -webkit-box;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 3;
     }
-    .has-mobile-left-margin {
+    .has-left-margin-mobile {
       margin-left: 5px;
     }
   }

--- a/src/components/cards/utils/CardRow.vue
+++ b/src/components/cards/utils/CardRow.vue
@@ -15,7 +15,16 @@ div{
     color:$text;
     align-items: center;
     justify-content: space-between;
-    display:flex;
+    display: flex;
+}
+
+@media screen and (max-width: $tablet) {
+  div {
+    align-items: flex-start;
+  }
+  span.is-ellipsed, p.is-ellipsed {
+    white-space: normal;
+  }
 }
 
 div:not(:last-child){

--- a/src/components/generics/icons/IconActivity.vue
+++ b/src/components/generics/icons/IconActivity.vue
@@ -1,5 +1,5 @@
 <template>
-  <fa-icon :icon="['activity', activity]" :class="'no-print'"/>
+  <fa-icon :icon="['activity', activity]" :class="'no-print'" />
 </template>
 
 <script>

--- a/src/js/vue-plugins/strip-markdown.js
+++ b/src/js/vue-plugins/strip-markdown.js
@@ -5,6 +5,6 @@ export default function install(Vue) {
     return value
       .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // external links
       .replace(/\[\[[^|]+|([^\]]+)\]\]/g, '$1') // internal links
-      .replace(/\**/g, ''); // emphasis
+      .replace(/[*_-#~`]/g, ''); // emphasis, lists and other similar stuff
   });
 }

--- a/src/js/vue-plugins/strip-markdown.js
+++ b/src/js/vue-plugins/strip-markdown.js
@@ -1,0 +1,10 @@
+// A very basic (a.k.a not bullet-proof) filter to remove markdown content from summary
+
+export default function install(Vue) {
+  Vue.filter('stripMarkdown', function(value) {
+    return value
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // external links
+      .replace(/\[\[[^|]+|([^\]]+)\]\]/g, '$1') // internal links
+      .replace(/\**/g, ''); // emphasis
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ import globalComponents from '@/js/vue-plugins/generic-components';
 import helperWindow from '@/js/vue-plugins/helper-window';
 import imageViewer from '@/js/vue-plugins/image-viewer';
 import localStorage from '@/js/vue-plugins/local-storage';
+import stripMarkdown from '@/js/vue-plugins/strip-markdown';
 import upperCaseFirstLetter from '@/js/vue-plugins/uppercase-first-letter';
 import user from '@/js/vue-plugins/user';
 import vueMoment from '@/js/vue-plugins/vue-moment.js';
@@ -67,6 +68,7 @@ Vue.use(helperWindow); // vm.$helper property
 Vue.use(alertWindow); // vm.$alert property
 Vue.use(imageViewer);
 Vue.use(globalComponents); // Components available everywhere
+Vue.use(stripMarkdown); // stripMarkdown filter
 Vue.use(upperCaseFirstLetter); // upperCaseFirstLetter filter
 Vue.use(user); // vm.$user property
 


### PR DESCRIPTION
As there is only one card per line on mobile, there is no need to limit content as much as in other situations.

* No ellipsis on outing title
![image](https://user-images.githubusercontent.com/2234024/54739167-6fe6b600-4bb7-11e9-919a-24aa68adb56f.png)


* Summary can be up to 3 lines (Chrome), and 300 chars (others), stripping out markdown in a very simple manner.
![image](https://user-images.githubusercontent.com/2234024/54739131-49c11600-4bb7-11e9-9626-9d3d58632d93.png)
![image](https://user-images.githubusercontent.com/2234024/54739146-580f3200-4bb7-11e9-9c75-6f5e7dceca2a.png)
(in the last example, content was `Les articles "Vallée d'Aoste ski de randonnée" présentent les [590 itinéraires de ski de randonnée dans la Vallée d’Aoste](/routes#a=280072&act=skitouring) décrits dans le topoguide de Camptocamp, dont [**31 itinéraires de ski de randonnée dans le Valdigne S**](/routes#w=113000,360281,263201,104528,104446,444130,&act=skitouring).`)