### PR TITLE
add dashboard link in the navigation

### DIFF
--- a/src/views/Navigation.vue
+++ b/src/views/Navigation.vue
@@ -39,6 +39,12 @@
         </div>
       </div>
 
+      <div class="navigation-item" title="Dashboard">
+        <router-link :to="{name:'dashboard'}">
+          <fa-icon icon="list"/>
+        </router-link>
+      </div>
+
       <div v-if="!siteConfiguration.isProduction" class="navigation-item is-hidden-mobile" :title="'This page may contains bugs or incomplete features'">
         <fa-icon icon="bug" size="lg" class="has-text-danger" />
       </div>


### PR DESCRIPTION
Since we don't know yet what is the best way to integrate the dashboard, but this dashboard deserve a "place" (and a way to access it from the web site), I propose a link in the navigation, near the research box.