### PR TITLE
No ellipse for feed cards

### DIFF
--- a/src/components/cards/FeedCard.vue
+++ b/src/components/cards/FeedCard.vue
@@ -18,12 +18,12 @@
     </card-title>
 
     <card-row>
-      <document-title :document="item.document" class="is-ellipsed has-text-weight-bold" />
+      <document-title :document="item.document" class="has-text-weight-bold" />
       <span v-if="documentType=='outing'" class="is-nowrap has-left-margin-mobile">{{ dates }}</span>
     </card-row>
 
     <card-row v-if="locale && locale.summary">
-      <p class="is-ellipsed is-max-3-lines-height-mobile">{{ locale.summary | stripMarkdown | max300chars }}</p>
+      <p class="is-max-3-lines-height">{{ locale.summary | stripMarkdown | max300chars }}</p>
     </card-row>
 
     <card-row v-if="images.length!=0">
@@ -179,15 +179,16 @@
       border-left:0!important;
       border-right:0!important;
     }
-    .is-max-3-lines-height-mobile {
-      // proprietary stuff, supported on limited browsers
-      display: -webkit-box;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: 3;
-    }
     .has-left-margin-mobile {
       margin-left: 5px;
     }
+  }
+
+  .is-max-3-lines-height {
+    // proprietary stuff, supported on limited browsers
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
   }
 
   .card-image-content{


### PR DESCRIPTION
There is no reason to restrict ellipsis removal to mobile for feed cards (this is different for other cards which need to keep same height)

![image](https://user-images.githubusercontent.com/2234024/55580837-baba0f00-571b-11e9-9d88-36fe62616b05.png)
