### PR TITLE
On mobile, when displaying search input, focus it

### DIFF
--- a/src/components/generics/inputs/InputDocument.vue
+++ b/src/components/generics/inputs/InputDocument.vue
@@ -2,6 +2,7 @@
   <div class="dropdown control" :class="{'is-active':promise.data}">
     <div class="control has-icons-left input-container">
       <input
+        ref="input"
         class="input"
         :class="{'is-danger':hasError}"
         type="text"
@@ -167,6 +168,10 @@
     },
 
     methods: {
+      focus() {
+        this.$refs.input.focus();
+      },
+
       closeDropdown() {
         this.promise = {};
       },

--- a/src/views/Navigation.vue
+++ b/src/views/Navigation.vue
@@ -23,6 +23,7 @@
     <div class="navigation-end">
       <div ref="searchInputContainer">
         <input-document
+          ref="searchInput"
           class="navigation-item search-input"
           :class="{'is-hidden-mobile': hideSearchInput}"
           :document-type="['waypoint', 'route', 'article', 'book']"
@@ -33,7 +34,7 @@
         <div
           class="navigation-item is-hidden-tablet"
           :class="{'is-hidden-mobile': !hideSearchInput}">
-          <span class="button" @click="hideSearchInput=false">
+          <span class="button" @click="showSearchInput">
             <fa-icon icon="search" />
           </span>
         </div>
@@ -213,6 +214,15 @@
         if (!this.$refs.searchInputContainer.contains(event.target)) {
           this.hideSearchInput = true;
         }
+      },
+
+      showSearchInput() {
+        this.hideSearchInput = false;
+
+        // after DOM update, input will be visible, and focusable
+        this.$nextTick(() => {
+          this.$refs.searchInput.focus();
+        });
       }
     }
   };


### PR DESCRIPTION
On mobile, search input is hidden in navbar. A button display it. When clicking on it, input is not focused, user has to click a second time on input.