### PR TITLE
Fix ie11 main bug #496. Fix multiple swiper bundle #495

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,13 @@
 module.exports = {
   presets: [
-    '@vue/app'
+    ['@vue/app', {
+      polyfills: [
+        'es6.promise',
+        'es6.symbol',
+        'es6.array.from',
+        'es6.object.assign',
+        'es7.object.values'
+      ]
+    }]
   ]
 };

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "> 1%",
     "last 2 versions",
     "not dead",
-    "not ie <= 8",
+    "not ie <= 10",
     "Chrome 41"
   ]
 }

--- a/src/components/image-viewer/ImageViewer.vue
+++ b/src/components/image-viewer/ImageViewer.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script>
-  import Swiper from 'swiper/dist/js/swiper.esm.bundle';
+  import Swiper from 'swiper/dist/js/swiper.js';
 
   import imageUrls from '@/js/image-urls';
   import ImageInfo from './ImageInfo';


### PR DESCRIPTION
IE11 fails, because some polyfills was missing. 

And the way we include swiper for ImageViewer (targeting esm bundle) causes it to be excluded from babel process, and causes a double inclusion in final bundle.

So here is a fix for #496 and #495 