### PR TITLE
Association editor - Image link

### DIFF
--- a/src/assets/sass/main.scss
+++ b/src/assets/sass/main.scss
@@ -16,6 +16,7 @@
 @import "~bulma/sass/elements/content.sass";
 @import "~bulma/sass/elements/form.sass";
 @import "~bulma/sass/elements/icon.sass";
+@import "~bulma/sass/elements/image.sass";
 @import "~bulma/sass/elements/notification.sass";
 @import "~bulma/sass/elements/progress.sass";
 @import "~bulma/sass/elements/other.sass";

--- a/src/components/association-editor/AssociationImageLink.vue
+++ b/src/components/association-editor/AssociationImageLink.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <document-link :document="image" class="has-hover-background">
+  <document-link :document="image" class="has-hover-background" target="_blank">
     <figure class="image is-96x96 association-image-link-child">
       <img :src="getUrl(image)" :title="image.locales[0].title">
     </figure>

--- a/src/components/association-editor/AssociationImageLink.vue
+++ b/src/components/association-editor/AssociationImageLink.vue
@@ -4,7 +4,9 @@
     <figure class="image is-96x96 association-image-link-child">
       <img :src="getUrl(image)" :title="image.locales[0].title">
     </figure>
-    <document-title :document="image" class="association-image-link-child"/>
+    <span class="association-image-link-child">
+      {{ image.locales[0].title | max50chars }}
+    </span>
   </document-link>
 
 </template>
@@ -13,6 +15,10 @@
   import imageUrls from '@/js/image-urls';
 
   export default {
+    filters: {
+      max50chars: value => value.length > 50 ? value.substring(0, 50) + '…' : value
+    },
+
     props: {
       image: {
         type: Object,

--- a/src/components/association-editor/AssociationImageLink.vue
+++ b/src/components/association-editor/AssociationImageLink.vue
@@ -1,0 +1,41 @@
+<template>
+
+  <document-link :document="image" class="has-hover-background">
+    <figure class="image is-96x96 association-image-link-child">
+      <img :src="getUrl(image)" :title="image.locales[0].title">
+    </figure>
+    <document-title :document="image" class="association-image-link-child"/>
+  </document-link>
+
+</template>
+
+<script>
+  import imageUrls from '@/js/image-urls';
+
+  export default {
+    props: {
+      image: {
+        type: Object,
+        required: true
+      }
+    },
+
+    methods: {
+      getUrl(image) {
+        return imageUrls.getSquared(image);
+      }
+    }
+  };
+</script>
+
+<style scoped lang="scss">
+
+    .association-image-link-child{
+        display:table-cell;
+        vertical-align: middle;
+    }
+
+    .association-image-link-child:last-child{
+        padding-left: 10px;
+    }
+</style>

--- a/src/components/association-editor/AssociationItems.vue
+++ b/src/components/association-editor/AssociationItems.vue
@@ -21,6 +21,8 @@
 
         <association-outing-link v-else-if="childType==='outing'" :outing="child.document" />
 
+        <association-image-link v-else-if="childType==='image'" :image="child.document" />
+
         <pretty-route-link
           v-else-if="childType==='route'"
           :route="child.document"
@@ -58,9 +60,13 @@
 <script>
   import c2c from '@/js/apis/c2c';
   import AssociationOutingLink from './AssociationOutingLink';
+  import AssociationImageLink from './AssociationImageLink';
 
   export default {
-    components: { AssociationOutingLink },
+    components: {
+      AssociationOutingLink,
+      AssociationImageLink
+      },
 
     props: {
 

--- a/src/components/association-editor/AssociationItems.vue
+++ b/src/components/association-editor/AssociationItems.vue
@@ -66,7 +66,7 @@
     components: {
       AssociationOutingLink,
       AssociationImageLink
-      },
+    },
 
     props: {
 


### PR DESCRIPTION
Related to [issue 561](https://github.com/c2corg/c2c_ui/issues/561)

Add a small view of the image and the title (when exist) after :

- image are small in order to display three of them on mobile
- there is enought place to display the title

Open the link in a new tab.

![image](https://user-images.githubusercontent.com/24532066/56356764-0c619f80-61da-11e9-8cde-62fd3351dd86.png)
