### PR TITLE
"Add button" in navigation

### DIFF
--- a/src/views/Navigation.vue
+++ b/src/views/Navigation.vue
@@ -63,7 +63,7 @@
       </div>
 
       <div class="navigation-item">
-        <dropdown-button class="is-right" ref="addDocumentMenu">
+        <dropdown-button class="is-right add-button" ref="addDocumentMenu">
           <span slot="button" class="button is-success">
             <fa-icon icon="plus" />
           </span>
@@ -374,4 +374,17 @@
       margin-right:0;
     }
   }
+</style>
+
+<style lang="scss">
+
+  @import '@/assets/sass/variables.scss';
+
+  @media screen and (max-width: $tablet){
+
+    .add-button .dropdown-content{
+      position: fixed;
+    }
+  }
+
 </style>

--- a/src/views/Navigation.vue
+++ b/src/views/Navigation.vue
@@ -68,10 +68,10 @@
             <fa-icon icon="plus" />
           </span>
           <add-link
-            v-for="documentType of ['outing', 'route', 'waypoint', 'article', 'book']"
+            v-for="documentType of ['outing', 'route', 'waypoint', 'article', 'book', 'xreport']"
             :key="documentType"
             :document-type="documentType"
-            class="dropdown-item is-size-5"
+            class="dropdown-item is-size-5 is-ellipsed"
             @click.native="$refs.addDocumentMenu.isActive = false">
             <icon-document :document-type="documentType" />
             <span>
@@ -384,6 +384,8 @@
 
     .add-button .dropdown-content{
       position: fixed;
+      right: 0;
+      max-width: 100%;
     }
   }
 


### PR DESCRIPTION
The add button in navigation doesn't render well on mobile because links are not completely visible.
![image](https://user-images.githubusercontent.com/24532066/56790925-1e5cc700-6806-11e9-88dc-f4929280ac90.png)
And xreport is missing in the list.