### PR TITLE
CI : on release, add git log to release description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 
 script:
 - npm run lint:no-fix
+- sh scripts/update-release-description.sh
 # - npm run test
 
 # always build docker image

--- a/scripts/update-release-description.js
+++ b/scripts/update-release-description.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const axios = require('axios');
+
+const repoSlug = process.env.TRAVIS_REPO_SLUG;
+const tagName = process.env.TRAVIS_TAG;
+const githubUsername = process.env.GITHUB_USERNAME;
+const githubToken = process.env.GITHUB_TOKEN;
+
+const gitLog = fs.readFileSync('/dev/stdin', 'utf-8');
+console.log(`git log : \n${gitLog}`);
+
+console.log(`getting release data on https://api.github.com/repos/${repoSlug}/releases/tags/${tagName}`);
+
+axios.get(`https://api.github.com/repos/${repoSlug}/releases/tags/${tagName}`)
+  .then((response) => {
+    const data = response.data;
+    const releaseUrl = data.url;
+
+    const payload = {
+      'tag_name': data.tag_name,
+      'target_commitish': data.target_commitish,
+      'name': data.name,
+      'body': gitLog,
+      'draft': data.draft,
+      'prerelease': data.prerelease
+    };
+
+    console.log('Update release data');
+
+    axios.patch(releaseUrl, payload, {
+      auth: {
+        username: githubUsername,
+        password: githubToken
+      }
+    })
+      .then(() => {
+        console.log('Release is updated');
+      })
+      .catch(() => {
+        console.log('Unexpected error. Ouput has been disabled on purpose for security reasons');
+        process.exit(1);
+    });
+  })
+  .catch(() => {
+    console.log('Unexpected error. Ouput has been disabled on purpose for security reasons');
+    process.exit(1);
+  }
+);

--- a/scripts/update-release-description.sh
+++ b/scripts/update-release-description.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+# if it's a tag, add commit logs
+if [ $TRAVIS_TAG ]; then
+    firstTag=$(git tag | sort -r | head -1)
+    secondTag=$(git tag | sort -r | head -2 | awk '{split($0, tags, "\n")} END {print tags[1]}')
+    git log  --pretty=oneline ${secondTag}..${firstTag} --no-merges | node scripts/update-release-description.js
+fi


### PR DESCRIPTION
When a release is added on github, this script will add in release description the result of `git log --pretty=oneline <last-release-name>..<current-release-name> --no-merges`