### PR TITLE
Add `flex-shrink: 0` to row image to ensure size sticks at 24px

### DIFF
--- a/src/views/portals/utils/ForumWidget.vue
+++ b/src/views/portals/utils/ForumWidget.vue
@@ -154,6 +154,7 @@
       border-radius: 50%;
       vertical-align: top;
       height: 100%;
+      flex-shrink: 0;
     }
 
     span{


### PR DESCRIPTION
A fix for #610 