### PR TITLE
Document view - Modify layout columns to layout grid

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -131,9 +131,9 @@
     @media screen and (min-width: $tablet){
       .wrapper{
         display: grid;
-        grid-template-columns: 1fr 2fr;
+        grid-template-columns: 23% auto; //need to fix the first column for the is-ellipsed to work, 1fr 3fr doesn't work
         grid-template-rows: auto 1fr;
-        grid-gap: 0.75rem;
+        grid-gap: 1.5rem;
       }
 
       .item1, .item3{

--- a/src/App.vue
+++ b/src/App.vue
@@ -117,6 +117,37 @@
     flex-flow: column;
   }
 
+  .wrapper{
+    display: flex;
+    flex-direction: column;
+  }
+
+  .item1, .item2, .item3{
+    width: 100%;
+  }
+
+
+  @supports (display: grid){
+
+    @media screen and (min-width: $tablet){
+      .wrapper{
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        grid-template-rows: auto 1fr;
+        grid-gap: 0.75rem;
+      }
+
+      .item1, .item3{
+        grid-column: 1;
+      }
+
+      .item2 {
+        grid-column: 2;
+        grid-row: 1 / span 2;
+      }
+    }
+  }
+
   @media screen and (max-width: $tablet) {
 
     .side-menu{

--- a/src/App.vue
+++ b/src/App.vue
@@ -126,7 +126,6 @@
     width: 100%;
   }
 
-
   @supports (display: grid){
 
     @media screen and (min-width: $tablet){

--- a/src/views/document/AreaView.vue
+++ b/src/views/document/AreaView.vue
@@ -1,17 +1,16 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns">
-      <div class="column is-3">
+    <div v-if="document" class="wrapper">
+      <div class="item1">
         <div class="box">
           <field-view :document="document" :field="fields.area_type" />
           <field-view :document="document" :field="fields.quality" />
         </div>
         <map-box :document="document" />
-        <tool-box :document="document" />
       </div>
 
-      <div class="column is-9">
+      <div class="item2">
         <div class="box" v-if="document.cooked.summary || document.cooked.description">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.description" />
@@ -40,6 +39,10 @@
         <images-box :document="document" />
 
         <comments-box :document="document" />
+      </div>
+
+      <div class="item3">
+        <tool-box :document="document" />
       </div>
     </div>
   </div>

--- a/src/views/document/ArticleView.vue
+++ b/src/views/document/ArticleView.vue
@@ -2,7 +2,7 @@
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
     <div v-if="document" class="wrapper is-block-print">
-      <div class="item1 is-12-print">
+      <div class="item1">
         <div class="box">
           <activities-field :document="document" />
           <field-view :document="document" :field="fields.categories" />
@@ -13,7 +13,7 @@
           <field-view :document="document" :field="fields.quality" />
         </div>
       </div>
-      <div class="item2 is-12-print">
+      <div class="item2">
         <div class="box">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.description" hide-title />

--- a/src/views/document/ArticleView.vue
+++ b/src/views/document/ArticleView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns is-block-print">
-      <div class="column is-3 is-12-print">
+    <div v-if="document" class="wrapper is-block-print">
+      <div class="item1 is-12-print">
         <div class="box">
           <activities-field :document="document" />
           <field-view :document="document" :field="fields.categories" />
@@ -12,10 +12,8 @@
           </label-value>
           <field-view :document="document" :field="fields.quality" />
         </div>
-
-        <tool-box :document="document" />
       </div>
-      <div class="column is-9 is-12-print">
+      <div class="item2 is-12-print">
         <div class="box">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.description" hide-title />
@@ -26,6 +24,10 @@
         <recent-outings-box v-if="!isDraftView" :document="document" />
         <images-box v-if="!isDraftView" :document="document" />
         <comments-box v-if="!isDraftView" :document="document" />
+      </div>
+
+      <div class="item3">
+        <tool-box :document="document" />
       </div>
     </div>
   </div>

--- a/src/views/document/BookView.vue
+++ b/src/views/document/BookView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns is-block-print">
-      <div class="column is-3">
+    <div v-if="document" class="wrapper is-block-print">
+      <div class="item1">
         <div class="box">
           <activities-field :document="document" />
           <field-view :document="document" :field="fields.author" />
@@ -16,11 +16,9 @@
           <field-view :document="document" :field="fields.quality" />
         </div>
 
-        <tool-box :document="document" />
-
       </div>
 
-      <div class="column is-9">
+      <div class="item2">
         <div class="box">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.description" hide-title />
@@ -32,6 +30,10 @@
         <images-box :document="document" />
 
         <comments-box :document="document" />
+      </div>
+
+      <div class="item3">
+        <tool-box :document="document" />
       </div>
     </div>
   </div>

--- a/src/views/document/ImageView.vue
+++ b/src/views/document/ImageView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns">
-      <div class="column is-3">
+    <div v-if="document" class="wrapper">
+      <div class="item1">
         <div class="box">
           <activities-field v-if="document.activities && document.activities.length" :document="document" />
 
@@ -34,11 +34,9 @@
         </div>
 
         <map-box :document="document" />
-
-        <tool-box :document="document" />
       </div>
 
-      <div class="column is-9">
+      <div class="item2">
         <div class="box is-paddingless">
           <a :href="getOriginalImageUrl(document)">
             <img class="main-image" :src="getBigImageUrl(document)">
@@ -56,6 +54,10 @@
         <images-box v-if="document" :document="document" />
         <comments-box :document="document" />
 
+      </div>
+
+      <div class="item3">
+        <tool-box :document="document" />
       </div>
 
     </div>

--- a/src/views/document/OutingView.vue
+++ b/src/views/document/OutingView.vue
@@ -10,7 +10,7 @@
         <map-box :document="document" />
       </div>
 
-      <div class="item2 is-12-print">
+      <div class="item2">
 
         <div class="box">
 

--- a/src/views/document/OutingView.vue
+++ b/src/views/document/OutingView.vue
@@ -4,14 +4,13 @@
 
     <images-box v-if="document" :document="document" />
 
-    <div v-if="document" class="columns is-multiline is-block-print">
+    <div v-if="document" class="wrapper is-block-print">
 
-      <div class="column is-3 no-print">
+      <div class="item1 no-print">
         <map-box :document="document" />
-        <tool-box :document="document" />
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div class="item2 is-12-print">
 
         <div class="box">
 
@@ -107,6 +106,10 @@
 
         <comments-box :document="document" />
 
+      </div>
+
+      <div class="item3">
+        <tool-box :document="document" />
       </div>
     </div>
   </div>

--- a/src/views/document/RouteView.vue
+++ b/src/views/document/RouteView.vue
@@ -8,7 +8,7 @@
         <map-box :document="document" @has-protection-area="hasProtectionArea=true" />
       </div>
 
-      <div class="item2 is-12-print">
+      <div class="item2">
         <!--   CONTENT  -->
 
         <div class="box">

--- a/src/views/document/RouteView.vue
+++ b/src/views/document/RouteView.vue
@@ -2,14 +2,13 @@
   <div class="section has-background-white-print">
 
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns is-block-print">
+    <div v-if="document" class="wrapper is-block-print">
 
-      <div class="column is-3 no-print">
+      <div class="item1 no-print">
         <map-box :document="document" @has-protection-area="hasProtectionArea=true" />
-        <tool-box :document="document" />
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div class="item2 is-12-print">
         <!--   CONTENT  -->
 
         <div class="box">
@@ -126,6 +125,10 @@
 
         <comments-box :document="document" />
 
+      </div>
+
+      <div class="item3">
+        <tool-box :document="document" />
       </div>
     </div>
   </div>

--- a/src/views/document/WaypointView.vue
+++ b/src/views/document/WaypointView.vue
@@ -12,7 +12,7 @@
         <map-box :document="document" />
       </div>
 
-      <div class="item2 is-12-print">
+      <div class="item2">
         <div class="box">
           <div class="columns is-multiline">
             <div class="column is-4">

--- a/src/views/document/WaypointView.vue
+++ b/src/views/document/WaypointView.vue
@@ -7,13 +7,12 @@
         :waypoint-type="document.waypoint_type" />
     </document-view-header>
 
-    <div v-if="document" class="columns">
-      <div class="column is-3 no-print">
+    <div v-if="document" class="wrapper">
+      <div class="item1 no-print">
         <map-box :document="document" />
-        <tool-box :document="document" />
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div class="item2 is-12-print">
         <div class="box">
           <div class="columns is-multiline">
             <div class="column is-4">
@@ -115,6 +114,10 @@
         <recent-outings-box v-if="!isDraftView" :document="document" />
         <images-box v-if="!isDraftView" :document="document" />
         <comments-box v-if="!isDraftView" :document="document" />
+      </div>
+
+      <div class="item3">
+        <tool-box :document="document" />
       </div>
     </div>
   </div>

--- a/src/views/document/XreportView.vue
+++ b/src/views/document/XreportView.vue
@@ -2,7 +2,7 @@
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
     <div v-if="document" class="wrapper is-block-print">
-      <div class="item1 is-12-print">
+      <div class="item1">
 
         <div class="box">
           <activities-field :document="document" />

--- a/src/views/document/XreportView.vue
+++ b/src/views/document/XreportView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns is-block-print">
-      <div class="column is-3 is-12-print">
+    <div v-if="document" class="wrapper is-block-print">
+      <div class="item1 is-12-print">
 
         <div class="box">
           <activities-field :document="document" />
@@ -27,10 +27,9 @@
         </div>
 
         <map-box :document="document" />
-        <tool-box :document="document" />
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div class="item2">
         <div class="box">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.description" />
@@ -54,6 +53,10 @@
 
         <comments-box :document="document" />
 
+      </div>
+
+      <div class="item3">
+        <tool-box :document="document" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
In order to put the toolbox at the end of the page on mobile and small screen, we have studied different options. We must think of a new layout that doesn't put the toolbox in the same column than the other informations that we want to display first on mobile.
Grid layout seems to be the easiest way to display boxes on two columns without nesting elements.

I have not modified the user's profile page because putting the Toolbox at the end of the page is not a good idea (since the user feed has an infinite scroll...).

### What is done : 
We have a basic flex display with boxes that are 100% wide.
For browsers which support the grid layout and if the screen is larger than $tablet, then we display in grid.
Browsers which do not support grid layout (and browsers which do not support @supports in css...) will have the same layout than mobile. => IE (doesn't support @supports) / Opera mini, Blackberry Browser, QQ Browser, Baidu Browser (doesn't support grid layout)

### Pro : 

- It does not duplicate the code
- It remains simple to maintain (anyway we already have a different css on mobile).

### Con : 

- Some browsers that could be used with large screen (IE...) will have the same layout than small screen => 2% of possible users.