### PR TITLE
Add a plugin that makes screen dimensions responsive

### DIFF
--- a/src/js/vue-plugins/screen.js
+++ b/src/js/vue-plugins/screen.js
@@ -1,0 +1,48 @@
+
+const BREAKPOINT_MOBILE = 768;
+const BREAKPOINT_TABLET = 1023;
+const BREAKPOINT_DESKTOP = 1215;
+const BREAKPOINT_WIDESCREEN = 1407;
+
+export default function install(Vue) {
+  Vue.prototype.$screen = new Vue({
+    name: 'Screen',
+
+    data() {
+      return {
+        width: window.innerWidth,
+        height: window.innerHeight
+      };
+    },
+
+    // https://bulma.io/documentation/modifiers/responsive-helpers/
+    computed: {
+      isMobile() {
+        return this.width <= BREAKPOINT_MOBILE;
+      },
+      isTablet() {
+        return this.width > BREAKPOINT_MOBILE && this.width <= BREAKPOINT_TABLET;
+      },
+      isDesktop() {
+        return this.width > BREAKPOINT_TABLET && this.width <= BREAKPOINT_DESKTOP;
+      },
+      isWidescreen() {
+        return this.width > BREAKPOINT_DESKTOP && this.width <= BREAKPOINT_WIDESCREEN;
+      },
+      isFullHD() {
+        return this.width > BREAKPOINT_WIDESCREEN;
+      }
+    },
+
+    created() {
+      window.addEventListener('resize', this.onResize);
+    },
+
+    methods: {
+      onResize() {
+        this.width = window.innerWidth;
+        this.height = window.innerHeight;
+      }
+    }
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ import globalComponents from '@/js/vue-plugins/generic-components';
 import helperWindow from '@/js/vue-plugins/helper-window';
 import imageViewer from '@/js/vue-plugins/image-viewer';
 import localStorage from '@/js/vue-plugins/local-storage';
+import screen from '@/js/vue-plugins/screen';
 import stripMarkdown from '@/js/vue-plugins/strip-markdown';
 import upperCaseFirstLetter from '@/js/vue-plugins/uppercase-first-letter';
 import user from '@/js/vue-plugins/user';
@@ -68,6 +69,7 @@ Vue.use(helperWindow); // vm.$helper property
 Vue.use(alertWindow); // vm.$alert property
 Vue.use(imageViewer);
 Vue.use(globalComponents); // Components available everywhere
+Vue.use(screen); // screen reactives properties
 Vue.use(stripMarkdown); // stripMarkdown filter
 Vue.use(upperCaseFirstLetter); // upperCaseFirstLetter filter
 Vue.use(user); // vm.$user property

--- a/src/views/SideMenu.vue
+++ b/src/views/SideMenu.vue
@@ -22,7 +22,7 @@
 
     <div class="menu-footer is-size-7">
       <!-- We must use JS to hide add, because we do not want that hidden add be taken add's stats -->
-      <advertisement class="menu-add" v-if="windowHeight>=630" />
+      <advertisement class="menu-add" v-if="$screen.height>=630" />
 
       <div class="has-text-centered menu-links">
         <router-link :to="{name:'article', params:{id:106727}}" v-translate>contact</router-link>
@@ -56,12 +56,6 @@
   export default {
     components: { Advertisement },
 
-    data() {
-      return {
-        windowHeight: 0
-      };
-    },
-
     computed: {
       // This must be computed, because it needs $gettext() function
       menuItems() {
@@ -72,17 +66,6 @@
           { name: 'serac', icon: 'icon-xreport', text: this.$gettext('Accident database'), activeFor: ['xreports', 'xreport', 'xreport-add'] },
           { name: 'articles', icon: 'icon-article', text: this.$gettext('articles'), activeFor: ['article'] }
         ];
-      }
-    },
-
-    mounted() {
-      this.onResize();
-      window.addEventListener('resize', this.onResize);
-    },
-
-    methods: {
-      onResize() {
-        this.windowHeight = window.innerHeight;
       }
     }
   };

--- a/src/views/document/ArticleView.vue
+++ b/src/views/document/ArticleView.vue
@@ -13,7 +13,7 @@
           <field-view :document="document" :field="fields.quality" />
         </div>
 
-        <tool-box :document="document" />
+        <tool-box :document="document" v-if="!$screen.isMobile" />
       </div>
       <div class="column is-9 is-12-print">
         <div class="box">
@@ -25,6 +25,7 @@
         <routes-box v-if="!isDraftView" :document="document" hide-buttons />
         <recent-outings-box v-if="!isDraftView" :document="document" />
         <images-box v-if="!isDraftView" :document="document" />
+        <tool-box :document="document" v-if="$screen.isMobile" />
         <comments-box v-if="!isDraftView" :document="document" />
       </div>
     </div>


### PR DESCRIPTION
How to solve the Mobile/desktop component order issue ? 

## The issue

On desktop, we must display : 

* a left column with components A, B, C
* a big right column with components D, E

it can be done with many different ways : bulma columns, css-grid, floating elements...

The issue is that, on mobiles, we have only one column. And elements on left columns must sometimes be displayed at the bottom. Let say for instance : A, B, D, E, C

And after many tries, we did not successfully succeed a way to do this in CSS in an elegant maneer (no code duplication, no DOM redundancy, easy to maintain, understandable, supported by all our browser).

## The solution

So the solution we'll use is reactive Vue properties. The downside is a small code replication, and design handled by JS. Upsides are all other points.

Here is how to use it : 

```html
<left-column>
  <component-A />
  <component-B />
  <component-C v-if="!$screen.isMobile"/>
</left-column>
<right-column>
  <component-D />
  <component-E />
  <component-C  v-if="$screen.isMobile"/>
</right-column>
```
 
