### PR TITLE
Move activities icons in associated route links

### DIFF
--- a/src/components/generics/pretty-links/PrettyRouteLink.vue
+++ b/src/components/generics/pretty-links/PrettyRouteLink.vue
@@ -1,11 +1,11 @@
 <template>
   <document-link :document="route" class="pretty-route-link has-hover-background">
+    <document-title :document="route" />
+    <span>&nbsp;</span>
     <activities
       v-if="!hideActivities"
       :activities="route.activities"
       class="is-size-3 has-text-secondary icon-activities" />
-    <span>&nbsp;</span>
-    <document-title :document="route" />,
     <span
       v-if="route.height_diff_difficulties && !hideHeightDiffDifficulties"
       :title="$gettext('height_diff_difficulties')"


### PR DESCRIPTION
As for now, when listing routes associated to an outing, the activities icons are shown first:

<img width="469" alt="Capture d’écran 2019-06-10 à 16 30 21" src="https://user-images.githubusercontent.com/1192331/59202577-0f0ac080-8b9d-11e9-9e0e-07fb6aa96d5e.png">

This PR suggests to move them after the route name because:
* the route name is the most important info, thus should be displayed first
* the activities are a route info, like the gradings and heights, it's more consistent to group them
* when several routes are associated, if several activities are available for a given route, it shifts the route names differently and makes it harder to read.

Here is what the change looks like:

<img width="460" alt="Capture d’écran 2019-06-10 à 16 33 28" src="https://user-images.githubusercontent.com/1192331/59202773-7fb1dd00-8b9d-11e9-8034-36fbaac77392.png">


