### PR TITLE
Improve image info rendering

### DIFF
--- a/src/components/image-viewer/ImageInfo.vue
+++ b/src/components/image-viewer/ImageInfo.vue
@@ -23,18 +23,14 @@
         <label>{{ $gettext(document.image_type) }}</label>
       </p>
 
-      <h4 class="title is-4 has-text-light" v-translate>
-        Settings
-      </h4>
-
       <ul>
         <li v-if="document.camera_name"> {{ document.camera_name }}</li>
-        <li v-if="document.exposure_time" :title="$gettext('exposure_time')">{{ document.exposure_time }}s</li>
-        <li v-if="document.fnumber" :title="$gettext('fnumber')">f/{{ document.fnumber }}</li>
+        <li v-if="document.exposure_time" :title="$gettext('exposure_time')">1/{{ Math.floor(1/document.exposure_time) }}&nbsp;s</li>
+        <li v-if="document.fnumber" :title="$gettext('fnumber')">f/{{ Math.round(document.fnumber * 10) / 10 }}</li>
         <li v-if="document.focal_length" :title="$gettext('focal_length')">{{ document.focal_length }}&nbsp;mm</li>
-        <li v-if="document.iso_speed" :title="$gettext('iso_speed')">{{ document.iso_speed }} ISO</li>
+        <li v-if="document.iso_speed" :title="$gettext('iso_speed')">{{ document.iso_speed }}&nbsp;ISO</li>
         <li v-if="document.width && document.height" :title="$gettext('resolution')">
-          {{ document.height }} x {{ document.width }} <span translate>pixels</span>
+          {{ document.height }} x {{ document.width }}&nbsp;<span translate>pixels</span>
         </li>
       </ul>
     </div>
@@ -85,5 +81,10 @@
     .image-info{
         background: rgba(0,0,0,0.7);
         padding:1rem;
+    }
+
+    /* FIXME seems not to work */
+    icon-creative-commons, fa-icon {
+        margin-right:1rem;
     }
 </style>

--- a/src/js/constants/fieldsProperties.json
+++ b/src/js/constants/fieldsProperties.json
@@ -373,7 +373,7 @@
         "type": "number",
         "min": 0,
         "max": 0,
-        "unit": "ms"
+        "unit": "s"
     },
     "external_resources":
     {

--- a/src/views/document/ImageView.vue
+++ b/src/views/document/ImageView.vue
@@ -26,7 +26,6 @@
           <field-view :document="document" :field="fields.fnumber" />
           <field-view :document="document" :field="fields.focal_length" />
           <field-view :document="document" :field="fields.iso_speed" />
-          <field-view :document="document" :field="fields.filename" />
           <field-view :document="document" :field="fields.file_size" unit="ko" :divisor="1024" />
           <field-view :document="document" :field="fields.height" />
           <field-view :document="document" :field="fields.width" />


### PR DESCRIPTION
This PR makes changes both in the image main pages and in the info section of the images viewer.

## Image main pages

TODO:
* [x] remove filename (who cares?)
* [x] exposure_time: change unit from "ms" to "s"
* [ ] display exposure_time as eg. "1/1600 s", which is the usual way to display it in photography and is much more readable than floats with many digits (eg. 0.00050000002375297)
* [ ] convert datetime to localtime instead of GMT time
* [ ] fnumber: add prefixing "f/" (+ rename title to "Ouverture" instead of "Propriétés de l'image" which is way too general)

Perhaps we could get rid of all those field titles (as in the viewer)?

I don't know yet how to do the uncheck items above. Any suggestions?

BEFORE: 
<img width="279" alt="Capture d’écran 2019-06-10 à 18 12 35" src="https://user-images.githubusercontent.com/1192331/59209325-5d26c080-8bab-11e9-9b26-5cd63e5f793e.png">

AFTER:
<img width="280" alt="Capture d’écran 2019-06-10 à 18 12 23" src="https://user-images.githubusercontent.com/1192331/59209345-69128280-8bab-11e9-8610-789c51febf3f.png">

## Image viewer info section

TODO:
* [x] remove useless "Settings" / "Infos" section header
* [x] display exposure_time as eg 1/1600 etc.
* [x] limit fnumber to max 1 digit after comma (I have encountered case like "6.30000012345")
* [ ] display datetime as local time instead of GMT time (ditto as for main page, see above)
* [ ] add some some margin after icons
* [ ] add author name

BEFORE:
<img width="348" alt="Capture d’écran 2019-06-10 à 18 24 13" src="https://user-images.githubusercontent.com/1192331/59210068-015d3700-8bad-11e9-8cda-cc48f74f5473.png">

AFTER:
<img width="297" alt="Capture d’écran 2019-06-10 à 18 24 25" src="https://user-images.githubusercontent.com/1192331/59210082-07531800-8bad-11e9-898e-6955f977a644.png">

