### PR TITLE
Fix: xerport edit button was not visible #702

### DIFF
--- a/src/views/document/utils/is-editable-mixin.js
+++ b/src/views/document/utils/is-editable-mixin.js
@@ -72,7 +72,21 @@ export default {
         return this.document.author.user_id === this.$user.id;
       }
 
-      if (['outing', 'xreport'].includes(this.documentType)) {
+      if (this.documentType === 'xreport') {
+        if (this.document.author.user_id === this.$user.id) {
+          return true;
+        }
+
+        for (const user of this.document.associations.users) {
+          if (user.document_id === this.$user.id) {
+            return true;
+          }
+        }
+
+        return false;
+      }
+
+      if (this.documentType === 'outing') {
         for (const user of this.document.associations.users) {
           if (user.document_id === this.$user.id) {
             return true;


### PR DESCRIPTION
The logic that determine if an user can edit an outing is if this user was in associated users.

I thought it was the same for xreports, as associated users array exists in xreports association.

But actually, there is an `author` field in xreport, and a simple xreport (only one user) has no associated users (even not the one who created it), and the test to perform is on `author` field.