### PR TITLE
fix: no edit button if document is protected #715

### DIFF
--- a/src/views/document/utils/is-editable-mixin.js
+++ b/src/views/document/utils/is-editable-mixin.js
@@ -56,6 +56,10 @@ export default {
         return true;
       }
 
+      if (this.document.protected) {
+        return false;
+      }
+
       if (['route', 'waypoint', 'area', 'book', 'map'].includes(this.documentType)) {
         return true;
       }


### PR DESCRIPTION
If document is protected, show edit button only if user is moderator