### PR TITLE
Use date_end as main date for outings instead of date_start

### DIFF
--- a/src/components/association-editor/AssociationOutingLink.vue
+++ b/src/components/association-editor/AssociationOutingLink.vue
@@ -1,7 +1,7 @@
 <template>
   <document-link :document="outing" class="pretty-outing-link has-hover-background" target="_blank">
     <span class="has-text-normal">
-      {{ outing.date_start }}&hairsp;&bull;&hairsp;{{ outing.author.name }} -
+      {{ outing.date_end }}&hairsp;&bull;&hairsp;{{ outing.author.name }} -
     </span>
     <document-title :document="outing" />
   </document-link>

--- a/src/components/cards/OutingCard.vue
+++ b/src/components/cards/OutingCard.vue
@@ -38,7 +38,7 @@
       </span>
 
       <span class="is-nowrap">
-        {{ $moment.toLocalizedString(document.date_start, "LL") }}
+        {{ $moment.toLocalizedString(document.date_end, "LL") }}
       </span>
 
       <marker-quality :quality="document.quality" />

--- a/src/components/datatable/DocumentsTable.vue
+++ b/src/components/datatable/DocumentsTable.vue
@@ -160,7 +160,7 @@
 
         if (this.documentType === 'outing') {
           this.columnDefs = [
-            getColDef(this, fields.date_start, { width: 120, cellRendererFramework: OutingDate }),
+            getColDef(this, fields.date_end, { width: 120, cellRendererFramework: OutingDate }),
             getColDef(this, fields.title, { cellRendererFramework: DocumentLink }),
             getColDef(this, { name: 'areas' }, { cellRendererFramework: AreaList }),
             getColDef(this, { name: 'contributor' }, { cellRendererFramework: DocumentContributor, width: 100 }),

--- a/src/components/datatable/cell-renderers/OutingDate.vue
+++ b/src/components/datatable/cell-renderers/OutingDate.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    {{ $moment.toLocalizedString(params.data.date_start, 'LL') }}
+    {{ $moment.toLocalizedString(params.data.date_end, 'LL') }}
   </span>
 </template>
 

--- a/src/components/generics/pretty-links/PrettyOutingLink.vue
+++ b/src/components/generics/pretty-links/PrettyOutingLink.vue
@@ -3,7 +3,7 @@
     <marker-quality :quality="outing.quality" class="has-text-normal" />
     <marker-condition :condition="outing.condition_rating" />
     <span class="has-text-normal">
-      {{ outing.date_start }}
+      {{ outing.date_end }}
       :
     </span>
     <document-title :document="outing" />


### PR DESCRIPTION
For multi-day outings, ``date_end`` is generally the most relevant date ("summit day").