### PR TITLE
Use -V option on sort #726

### DIFF
--- a/scripts/update-release-description.sh
+++ b/scripts/update-release-description.sh
@@ -2,7 +2,7 @@
 
 # if it's a tag, add commit logs
 if [ $TRAVIS_TAG ]; then
-    firstTag=$(git tag | sort -r | head -1)
-    secondTag=$(git tag | sort -r | head -2 | awk '{split($0, tags, "\n")} END {print tags[1]}')
+    firstTag=$(git tag | sort -V -r | head -1)
+    secondTag=$(git tag | sort -V -r | head -2 | awk '{split($0, tags, "\n")} END {print tags[1]}')
     git log  --pretty=oneline ${secondTag}..${firstTag} --no-merges | node scripts/update-release-description.js
 fi


### PR DESCRIPTION
`sort`by default makes a alphabetical sort : 

```
git tag | sort -r
v7.0.9
v7.0.8
v7.0.7
v7.0.6
v7.0.5
v7.0.4
v7.0.3
v7.0.2
v7.0.10
v7.0.1
v7.0.0
V7.0.4
```

The `-V` magic option stands for `version` :) 

```
git tag | sort -r -V
v7.0.10
v7.0.9
v7.0.8
v7.0.7
v7.0.6
v7.0.5
v7.0.4
v7.0.3
v7.0.2
v7.0.1
v7.0.0
V7.0.4
```
 