### PR TITLE
YETI: add links in UI

### DIFF
--- a/src/components/generics/icons/IconYeti.vue
+++ b/src/components/generics/icons/IconYeti.vue
@@ -1,0 +1,6 @@
+<template>
+  <fa-layers>
+    <fa-icon icon="square" transform="rotate-45 shrink-1" />
+    <fa-icon icon="exclamation" :style="{ color: 'white' }" transform="shrink-6" />
+  </fa-layers>
+</template>

--- a/src/components/map/OlMap.vue
+++ b/src/components/map/OlMap.vue
@@ -262,7 +262,9 @@
         // we must save initial geometry
         initialGeometry: null,
 
-        highlightedFeature: null
+        highlightedFeature: null,
+
+        minZoomLevel: DEFAULT_POINT_ZOOM
       };
     },
 
@@ -683,7 +685,7 @@
         this.view.fit(extent, { size: this.map.getSize() });
 
         // set a minimum zoom level
-        this.view.setZoom(Math.min(DEFAULT_POINT_ZOOM, this.view.getZoom()));
+        this.view.setZoom(Math.min(this.minZoomLevel, this.view.getZoom()));
       },
 
       toogleMapLayer(layer) {

--- a/src/components/yeti/YetiButton.vue
+++ b/src/components/yeti/YetiButton.vue
@@ -19,7 +19,7 @@
         return this.$route.name;
       },
       href() {
-        return '/yeti' + (this.document ? '/' + this.document.document_id : '');
+        return { name: 'yeti', params: { 'document_id': this.document ? this.document.document_id : null } };
       },
       isRouteDocumentType() {
         return this.documentType === 'route' || this.documentType === 'routes';

--- a/src/components/yeti/YetiButton.vue
+++ b/src/components/yeti/YetiButton.vue
@@ -1,0 +1,36 @@
+<template>
+  <router-link v-if="showButton" :to="href" class="button">
+    <icon-yeti class="icon" />
+    <span v-if="document">Voir dans YETI</span>
+    <span v-else>YETI</span>
+  </router-link>
+</template>
+
+<script>
+  export default {
+    props: {
+      document: {
+        type: Object,
+        default: null
+      }
+    },
+    computed: {
+      documentType() {
+        return this.$route.name;
+      },
+      href() {
+        return '/yeti' + (this.document ? '/' + this.document.document_id : '');
+      },
+      isRouteDocumentType() {
+        return this.documentType === 'route' || this.documentType === 'routes';
+      },
+      isActivitiesDocument() {
+        const activities = ['skitouring', 'snow_ice_mixed', 'ice_climbing', 'snowshoeing'];
+        return this.document.activities.some(activity => activities.includes(activity));
+      },
+      showButton() {
+        return this.isRouteDocumentType && (this.document ? this.isActivitiesDocument : true);
+      }
+    }
+  };
+</script>

--- a/src/js/vue-plugins/font-awesome-config.js
+++ b/src/js/vue-plugins/font-awesome-config.js
@@ -34,6 +34,7 @@ import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclama
 import { faExpand } from '@fortawesome/free-solid-svg-icons/faExpand';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons/faExternalLinkAlt';
 import { faEye } from '@fortawesome/free-solid-svg-icons/faEye';
+import { faExclamation } from '@fortawesome/free-solid-svg-icons/faExclamation';
 import { faFilter } from '@fortawesome/free-solid-svg-icons/faFilter';
 import { faFlag } from '@fortawesome/free-solid-svg-icons/faFlag';
 import { faFlagCheckered } from '@fortawesome/free-solid-svg-icons/faFlagCheckered';
@@ -72,6 +73,7 @@ import { faSignInAlt } from '@fortawesome/free-solid-svg-icons/faSignInAlt';
 import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons/faSignOutAlt';
 import { faSortAmountUp } from '@fortawesome/free-solid-svg-icons/faSortAmountUp';
 import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
+import { faSquare } from '@fortawesome/free-solid-svg-icons/faSquare';
 import { faSun } from '@fortawesome/free-solid-svg-icons/faSun';
 import { faTachometerAlt } from '@fortawesome/free-solid-svg-icons/faTachometerAlt';
 import { faTag } from '@fortawesome/free-solid-svg-icons/faTag';
@@ -240,6 +242,7 @@ export default function install(Vue) {
     faExpand,
     faExternalLinkAlt,
     faEye,
+    faExclamation,
     faFilter,
     faFlag,
     faFlagCheckered,
@@ -278,7 +281,7 @@ export default function install(Vue) {
     faSignOutAlt,
     faSortAmountUp,
     faStar,
-    //    faSquare,
+    faSquare,
     faSun,
     faTachometerAlt,
     faTag,

--- a/src/js/vue-plugins/font-awesome-config.js
+++ b/src/js/vue-plugins/font-awesome-config.js
@@ -30,11 +30,11 @@ import { faCompass } from '@fortawesome/free-solid-svg-icons/faCompass';
 import { faCompress } from '@fortawesome/free-solid-svg-icons/faCompress';
 import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase';
 import { faEdit } from '@fortawesome/free-solid-svg-icons/faEdit';
+import { faExclamation } from '@fortawesome/free-solid-svg-icons/faExclamation';
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle';
 import { faExpand } from '@fortawesome/free-solid-svg-icons/faExpand';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons/faExternalLinkAlt';
 import { faEye } from '@fortawesome/free-solid-svg-icons/faEye';
-import { faExclamation } from '@fortawesome/free-solid-svg-icons/faExclamation';
 import { faFilter } from '@fortawesome/free-solid-svg-icons/faFilter';
 import { faFlag } from '@fortawesome/free-solid-svg-icons/faFlag';
 import { faFlagCheckered } from '@fortawesome/free-solid-svg-icons/faFlagCheckered';
@@ -72,8 +72,8 @@ import { faShareAlt } from '@fortawesome/free-solid-svg-icons/faShareAlt';
 import { faSignInAlt } from '@fortawesome/free-solid-svg-icons/faSignInAlt';
 import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons/faSignOutAlt';
 import { faSortAmountUp } from '@fortawesome/free-solid-svg-icons/faSortAmountUp';
-import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
 import { faSquare } from '@fortawesome/free-solid-svg-icons/faSquare';
+import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
 import { faSun } from '@fortawesome/free-solid-svg-icons/faSun';
 import { faTachometerAlt } from '@fortawesome/free-solid-svg-icons/faTachometerAlt';
 import { faTag } from '@fortawesome/free-solid-svg-icons/faTag';
@@ -238,11 +238,11 @@ export default function install(Vue) {
     faCompress,
     faDatabase,
     faEdit,
+    faExclamation,
     faExclamationCircle,
     faExpand,
     faExternalLinkAlt,
     faEye,
-    faExclamation,
     faFilter,
     faFlag,
     faFlagCheckered,
@@ -280,8 +280,8 @@ export default function install(Vue) {
     faSignInAlt,
     faSignOutAlt,
     faSortAmountUp,
-    faStar,
     faSquare,
+    faStar,
     faSun,
     faTachometerAlt,
     faTag,

--- a/src/js/vue-plugins/router.js
+++ b/src/js/vue-plugins/router.js
@@ -62,7 +62,7 @@ const routes = [
   { path: '/following', name: 'following', component: FollowingView },
   { path: '/preferences', name: 'preferences', component: PreferencesView },
   { path: '/mailinglists', name: 'mailinglists', component: MailingListsView },
-  { path: '/yeti/:document(\\d+)?/:page?', name: 'yeti', component: YetiView },
+  { path: '/yeti/:document_id(\\d+)?/:page?', name: 'yeti', component: YetiView },
 
   { path: '/wip', name: 'workinprogress', component: WorkInProgressView },
 

--- a/src/js/vue-plugins/router.js
+++ b/src/js/vue-plugins/router.js
@@ -62,7 +62,7 @@ const routes = [
   { path: '/following', name: 'following', component: FollowingView },
   { path: '/preferences', name: 'preferences', component: PreferencesView },
   { path: '/mailinglists', name: 'mailinglists', component: MailingListsView },
-  { path: '/yeti/:page?', name: 'yeti', component: YetiView },
+  { path: '/yeti/:document(\\d+)?/:page?', name: 'yeti', component: YetiView },
 
   { path: '/wip', name: 'workinprogress', component: WorkInProgressView },
 

--- a/src/views/document/utils/boxes/MapBox.vue
+++ b/src/views/document/utils/boxes/MapBox.vue
@@ -21,15 +21,22 @@
 
     <elevation-profile :document="document" v-if="documentType=='outing'" />
 
-    <div
-      v-if="document.geometry && (document.geometry.geom_detail || documentType == 'waypoint')"
-      class="buttons is-centered">
-      <button class="button is-primary is-small" @click="downloadGpx">
-        GPX
-      </button>
-      <button class="button is-primary is-small" @click="downloadKml">
-        KML
-      </button>
+    <div class="columns is-multiline is-mobile is-clearfix">
+      <div class="column is-full-tablet is-full-desktop is-half-widescreen ">
+        <yeti-button :document="document" class="is-small" />
+      </div>
+      <div class="column">
+        <div
+          v-if="document.geometry && (document.geometry.geom_detail || documentType == 'waypoint')"
+          class="buttons is-pulled-right">
+          <button class="button is-primary is-small" @click="downloadGpx">
+            GPX
+          </button>
+          <button class="button is-primary is-small" @click="downloadKml">
+            KML
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -40,12 +47,14 @@
 
   import { requireDocumentProperty } from '@/js/properties-mixins';
   import ElevationProfile from './ElevationProfile';
+  import YetiButton from '@/components/yeti/YetiButton';
 
   const GeoJSON = new ol.format.GeoJSON();
 
   export default {
     components: {
-      ElevationProfile
+      ElevationProfile,
+      YetiButton
     },
 
     mixins: [ requireDocumentProperty ],

--- a/src/views/documents/utils/QueryItems.vue
+++ b/src/views/documents/utils/QueryItems.vue
@@ -38,7 +38,10 @@
       class="association-query-item is-hidden-mobile"
       :document-types="associations"
       @documents-load="$emit('documents-load', arguments[0])" />
+
     <load-user-preferences-button class="is-hidden-tablet" />
+
+    <yeti-button />
   </div>
 </template>
 
@@ -47,6 +50,7 @@
   import QueryItem from './QueryItem';
   import AssociationQueryItem from './AssociationQueryItem';
   import LoadUserPreferencesButton from './LoadUserPreferencesButton';
+  import YetiButton from '@/components/yeti/YetiButton';
 
   const categorizedFieldsDefault = {
     General: [
@@ -180,7 +184,8 @@
     components: {
       QueryItem,
       AssociationQueryItem,
-      LoadUserPreferencesButton
+      LoadUserPreferencesButton,
+      YetiButton
     },
 
     computed: {

--- a/src/views/portals/YetiView.vue
+++ b/src/views/portals/YetiView.vue
@@ -330,13 +330,13 @@
             </div>
           </div>
 
-          <div class="box is-hidden-mobile" v-if="documents">
+          <div class="box is-hidden-mobile" v-if="document">
             <div class="title is-4 document-title">
               Route
             </div>
-            <document-link :document="documents[0]">
+            <document-link :document="document">
               <icon-route class="document-icon" />
-              <document-title :document="documents[0]" />
+              <document-title :document="document" />
             </document-link>
           </div>
 
@@ -392,7 +392,7 @@
                 @change="onUpdateOpacityYetiLayer" />
             </div>
           </div>
-          <map-view ref="map" @zoom="mapZoom = arguments[0]" show-recenter-on :documents="documents" />
+          <map-view ref="map" @zoom="mapZoom = arguments[0]" show-recenter-on :documents="document ? [document] : null" />
         </div>
       </div>
     </div>
@@ -517,7 +517,7 @@
         promiseMountains: null,
         showMountainsList: false,
 
-        documents: null
+        document: null
       };
     },
 
@@ -586,8 +586,8 @@
           // set min zoom for map
           // (that will be used after document is displayed and map is fitted to extent)
           this.$refs.map.minZoomLevel = VALID_FORM_DATA.minZoom;
-          // add documents
-          this.documents = [doc.data];
+          // add document
+          this.document = doc.data;
           // put document layers on top
           ['documentsLayer', 'waypointsLayer'].forEach(layer => {
             this.$refs.map[layer].setZIndex(1);

--- a/src/views/portals/YetiView.vue
+++ b/src/views/portals/YetiView.vue
@@ -579,7 +579,7 @@
 
     mounted() {
       this.check();
-      const doc = this.$route.params.document;
+      const doc = this.$route.params.document_id;
       const lang = this.$language.current;
       if (doc) {
         c2c['route'].getCooked(doc, lang).then(doc => {

--- a/src/views/portals/YetiView.vue
+++ b/src/views/portals/YetiView.vue
@@ -330,6 +330,16 @@
             </div>
           </div>
 
+          <div class="box is-hidden-mobile" v-if="documents">
+            <div class="title is-4 document-title">
+              Route
+            </div>
+            <document-link :document="documents[0]">
+              <icon-route class="document-icon" />
+              <document-title :document="documents[0]" />
+            </document-link>
+          </div>
+
           <div class="box yeti-logos">
             <div class="columns is-mobile is-vcentered">
               <div class="column has-text-centered">
@@ -1323,6 +1333,16 @@
     right: 0;
     left: 0;
     min-height: 100%;
+  }
+
+  .document-title {
+    margin-bottom: 0.5rem !important;
+  }
+
+  .document-icon,
+  .document-icon:hover {
+    color: $dark;
+    margin-right: 3px;
   }
 </style>
 


### PR DESCRIPTION
This PR adds YETI links inside UI:

- on `/routes` page (at the top)
- on each `/routes/{id}` pages when activity is one of `skitouring`, `snow_ice_mixed`, `ice_climbing` or `snowshoeing` (below map, same line as GPX, KML buttons)
    - document data will be loaded inside YETI, on top of YETI layer
    - a go-back link to that route is also added

All changes are made inside YETI page and/or components.
Only one is made inside `OLMap` component: I added ability to force `minZoomLevel` when map is fitted to one document (allow YETI to set minimum accepted zoom for computation, when a document is loaded)
