### PR TITLE
YETI Hotfix: Map can't be moved and/or zoomed when a document is loaded 

### DIFF
--- a/src/views/portals/YetiView.vue
+++ b/src/views/portals/YetiView.vue
@@ -392,7 +392,7 @@
                 @change="onUpdateOpacityYetiLayer" />
             </div>
           </div>
-          <map-view ref="map" @zoom="mapZoom = arguments[0]" show-recenter-on :documents="document ? [document] : null" />
+          <map-view ref="map" @zoom="mapZoom = arguments[0]" show-recenter-on :documents="documents" />
         </div>
       </div>
     </div>
@@ -561,6 +561,10 @@
 
       document() {
         return (this.promiseDocument && this.promiseDocument.data) ? this.promiseDocument.data : null;
+      },
+
+      documents() {
+        return this.document ? [this.document] : null;
       }
 
     },


### PR DESCRIPTION
Fix: Pass document as array from computed properties. Otherwise, a new array is passed every time the map move (and so, is fitted again)