### PR TITLE
if branch name contains a slash

### DIFF
--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -8,12 +8,13 @@
 # clone repository on gh-pages branch. Save it in gh-pages folder
 git clone --single-branch --branch=gh-pages https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
 
+export CLEANED_TRAVIS_BRANCH=${TRAVIS_BRANCH/\//-}
 # move build into gh-pages folder, under a new folder with <branch-name> as name
-rm -rf gh-pages/$TRAVIS_BRANCH
-mv dist gh-pages/$TRAVIS_BRANCH
+rm -rf gh-pages/$CLEANED_TRAVIS_BRANCH
+mv dist gh-pages/$CLEANED_TRAVIS_BRANCH
 
 # Add this folder into gh-pages branch, commit and push
 cd gh-pages
 git add .
-git commit -m "Deploy $TRAVIS_BRANCH branch"
+git commit -m "Deploy $CLEANED_TRAVIS_BRANCH branch"
 git push > /dev/null 2>&1


### PR DESCRIPTION
Small fix : if branch name contains a slash, replace it by a dash in gh-page. It will fix the deploy issue on improve_SERAC branch.