### PR TITLE
Add lang attribute for sections when document and interface langs differ

### DIFF
--- a/src/js/vue-plugins/gettext-plugin.js
+++ b/src/js/vue-plugins/gettext-plugin.js
@@ -119,7 +119,7 @@ export default function install(Vue) {
         // save in locale storage
         this.$localStorage.set('current', lang);
 
-        // is user is logged, we need to save in db his preference
+        // if user is logged, we need to save in db his preference
         this.$user.saveLangPreference(lang);
 
         // then, we must defer lang setter

--- a/src/js/vue-plugins/gettext-plugin.js
+++ b/src/js/vue-plugins/gettext-plugin.js
@@ -127,7 +127,7 @@ export default function install(Vue) {
         this._getMessages(lang).then(() => {
           this.current = lang;
           // set html lang attribute
-          document.documentElement.setAttribute('lang', lang);
+          document.documentElement.setAttribute('lang', this.getIANALanguageSubtag(lang));
         });
       },
 
@@ -158,11 +158,30 @@ export default function install(Vue) {
         return getTranslation(this.current, this.translations[this.current], msgid, msgctxt);
       },
 
+      getIANALanguageSubtag(lang) {
+        switch (lang) {
+        case 'fr':
+        case 'en':
+        case 'ca':
+        case 'eu':
+        case 'it':
+        case 'de':
+        case 'es':
+          return lang;
+        case 'zh_CN':
+          return 'zh';
+        default:
+          // eslint-disable-next-line no-console
+          console.error(`Unexpected langauage: ${lang}`);
+          return lang;
+        }
+      },
+
       updateElement(element) {
         if (element.dataset.msgid === undefined) {
           if (element.childNodes.length > 1 || element.firstChild.nodeType !== TEXT_NODE) {
             // eslint-disable-next-line
-                        console.error("v-translate must contains only text", element.childNodes)
+            console.error("v-translate must contains only text", element.childNodes)
             return;
           }
 

--- a/src/views/document/utils/boxes/ToolBox.vue
+++ b/src/views/document/utils/boxes/ToolBox.vue
@@ -3,7 +3,7 @@
 
     <associated-documents :document="document" />
 
-    <div class="has-text-centered" v-if="isNormalView && available_langs.length>0">
+    <div class="has-text-centered" v-if="isNormalView && available_langs.length > 0">
       <span v-translate>View in other lang</span>
       <br>
       <span class="lang-switcher-box-list">

--- a/src/views/document/utils/field-viewers/MarkdownSection.vue
+++ b/src/views/document/utils/field-viewers/MarkdownSection.vue
@@ -48,7 +48,7 @@
       lang() {
         const current_lang = this.$language.current;
         const document_lang = this.document ? this.document.cooked.lang : null;
-        return document_lang === current_lang ? undefined : document_lang;
+        return document_lang === current_lang ? undefined : this.$language.getIANALanguageSubtag(document_lang);
       }
     }
   };

--- a/src/views/document/utils/field-viewers/MarkdownSection.vue
+++ b/src/views/document/utils/field-viewers/MarkdownSection.vue
@@ -48,7 +48,7 @@
       lang() {
         const current_lang = this.$language.current;
         const document_lang = this.document ? this.document.cooked.lang : null;
-        return document_lang === current_lang ? false : document_lang;
+        return document_lang === current_lang ? undefined : document_lang;
       }
     }
   };

--- a/src/views/document/utils/field-viewers/MarkdownSection.vue
+++ b/src/views/document/utils/field-viewers/MarkdownSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="(document.cooked[field.name] && field.isVisibleFor(document)) || $slots.after" class="markdown-section">
-    <h2 v-if="field.name !='summary' && !hideTitle" class="title is-2" :class="{'no-print': !visible}">
+    <h2 v-if="field.name != 'summary' && !hideTitle" class="title is-2" :class="{'no-print': !visible}">
       <span>
         {{ (title || $gettext(field.name)) | uppercaseFirstLetter }}
       </span>
@@ -10,10 +10,10 @@
         :rotation="visible ? undefined : 180"
         @click="visible=!visible" />
     </h2>
-    <div v-show="visible">
+    <div v-show="visible" :lang="lang">
       <markdown
         v-if="document.cooked[field.name]"
-        :class="{'is-italic':field.name==='summary'}"
+        :class="{'is-italic': field.name === 'summary'}"
         :content="document.cooked[field.name]" />
       <slot name="after" />
     </div>
@@ -42,6 +42,14 @@
       return {
         visible: true
       };
+    },
+
+    computed: {
+      lang() {
+        const current_lang = this.$language.current;
+        const document_lang = this.document ? this.document.cooked.lang : null;
+        return document_lang === current_lang ? false : document_lang;
+      }
     }
   };
 </script>


### PR DESCRIPTION
See #1071

I don't have any previous experience with vuejs, so maybe I'm not doing it the proper way.

I don't know if there are other places where the attribute should be added (maybe for document title?)

When this is ok, I can look for enabling translations (best UI for this to be defined)