### PR TITLE
nearby button allows open in a new tab 

### DIFF
--- a/src/views/document/utils/boxes/ToolBoxButton.vue
+++ b/src/views/document/utils/boxes/ToolBoxButton.vue
@@ -1,7 +1,23 @@
 <template>
-  <component
-    :is="to ? 'router-link' : (href ? 'a' : 'div')"
+  <!--Can't use component for router-link, it does not set the href attribute.
+    Surprisingly, it open the link, but it prevents user to open it in a new tab -->
+  <router-link
+    v-if="to"
     :to="to"
+    @click="$emit('click')"
+    class="toolbox-button">
+    <span class="toolbox-button-icon">
+      <slot name="icon">
+        <fa-icon :icon="icon" :class="iconClass" />
+      </slot>
+    </span>
+    <span>
+      {{ label | uppercaseFirstLetter }}
+    </span>
+  </router-link>
+  <component
+    v-else
+    :is="href ? 'a' : 'div'"
     @click="$emit('click')"
     :href="href"
     class="toolbox-button">


### PR DESCRIPTION
For #1093

Can't use component for router-link, it does not set the href attribute. Surprisingly, it open the link, but it prevents user to open it in a new tab.

Just use v-if / v-else to hack it.