### PR TITLE
Rework image upload logic

### DIFF
--- a/src/components/images-uploader/ImagesUploader.vue
+++ b/src/components/images-uploader/ImagesUploader.vue
@@ -253,6 +253,7 @@ export default {
 
     onUploadSuccess(document, image) {
       image.status = 'SUCCESS';
+
       Object.assign(image.document, document);
       this.computeReadyForSaving();
     },
@@ -260,7 +261,7 @@ export default {
     onUploadFailure(event, image) {
       image.percentCompleted = 100;
       image.status = 'FAILED';
-      image.errorMessage = event.message;
+      image.errorMessage = event?.message || this.$gettext('Image could not be processed');
     },
 
     computeReadyForSaving() {


### PR DESCRIPTION
* handle resizing in addition to orientation : no resizing for SVG, images under 2 MB. For other images, limit height to 2048px (thus allowing panos). The logic has flaws, but is quite simple and handles properly most cases.
* refactor code to use promises rather than callbacks, hopefully making it clearer
* handle errors

Fixes #1224 