### PR TITLE
Identify external links with icon

### DIFF
--- a/src/assets/sass/external-links.scss
+++ b/src/assets/sass/external-links.scss
@@ -1,7 +1,7 @@
 /* full links, like https://... http://... //... get an external link icon */
 $escaped-color-link: '%23#{str-slice(inspect($color-link), 2)}';
 
-a[href*="//"]:after
+a[href*="//"]::after
 {
   content: ' ';
   // Icon from https://fontawesome.com/icons/external-link-alt?style=solid (CC BY 4.0)
@@ -12,16 +12,16 @@ a[href*="//"]:after
 }
 
 /* except camptocamp full links */
-a[href^="https://www.camptocamp.org"]:after,
-a[href^="https://forum.camptocamp.org"]:after,
-a[href^="https://media.camptocamp.org"]:after
+a[href^="https://www.camptocamp.org"]::after,
+a[href^="https://forum.camptocamp.org"]::after,
+a[href^="https://media.camptocamp.org"]::after
 {
   content: none;
 }
 
 /* also hide the icon when printed */
 @media print {
-  a[href*="//"]:after
+  a[href*="//"]::after
   {
     content: none;
   }

--- a/src/assets/sass/external-links.scss
+++ b/src/assets/sass/external-links.scss
@@ -1,9 +1,11 @@
 /* full links, like https://... http://... //... get an external link icon */
+$escaped-color-link: '%23#{str-slice(inspect($color-link), 2)}';
+
 a[href*="//"]:after
 {
   content: ' ';
   // Icon from https://fontawesome.com/icons/external-link-alt?style=solid (CC BY 4.0)
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z'%3E%3C/path%3E%3C/svg%3E")
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path fill='#{$escaped-color-link}' d='M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z'></path></svg>")
     center no-repeat;
   padding-right: 1em;
   background-size: 0.6em;
@@ -11,7 +13,8 @@ a[href*="//"]:after
 
 /* except camptocamp full links */
 a[href^="https://www.camptocamp.org"]:after,
-a[href^="https://forum.camptocamp.org"]:after
+a[href^="https://forum.camptocamp.org"]:after,
+a[href^="https://media.camptocamp.org"]:after
 {
   content: none;
 }

--- a/src/assets/sass/external-links.scss
+++ b/src/assets/sass/external-links.scss
@@ -1,0 +1,25 @@
+/* full links, like https://... http://... //... get an external link icon */
+a[href*="//"]:after
+{
+  content: ' ';
+  // Icon from https://fontawesome.com/icons/external-link-alt?style=solid (CC BY 4.0)
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z'%3E%3C/path%3E%3C/svg%3E")
+    center no-repeat;
+  padding-right: 1em;
+  background-size: 0.6em;
+}
+
+/* except camptocamp full links */
+a[href^="https://www.camptocamp.org"]:after,
+a[href^="https://forum.camptocamp.org"]:after
+{
+  content: none;
+}
+
+/* also hide the icon when printed */
+@media print {
+  a[href*="//"]:after
+  {
+    content: none;
+  }
+}

--- a/src/assets/sass/external-links.scss
+++ b/src/assets/sass/external-links.scss
@@ -1,28 +1,31 @@
-/* full links, like https://... http://... //... get an external link icon */
+/* Full links in markdown content, like https://... http://... //... get an external link icon */
+
 $escaped-color-link: '%23#{str-slice(inspect($color-link), 2)}';
 
-a[href*="//"]::after
-{
-  content: ' ';
-  // Icon from https://fontawesome.com/icons/external-link-alt?style=solid (CC BY 4.0)
-  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path fill='#{$escaped-color-link}' d='M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z'></path></svg>")
-    center no-repeat;
-  padding-right: 1em;
-  background-size: 0.6em;
-}
-
-/* except camptocamp full links */
-a[href^="https://www.camptocamp.org"]::after,
-a[href^="https://forum.camptocamp.org"]::after,
-a[href^="https://media.camptocamp.org"]::after
-{
-  content: none;
-}
-
-/* also hide the icon when printed */
-@media print {
+.markdown-content {
   a[href*="//"]::after
   {
+    content: ' ';
+    // Icon from https://fontawesome.com/icons/external-link-alt?style=solid (CC BY 4.0)
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path fill='#{$escaped-color-link}' d='M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z'></path></svg>")
+      center no-repeat;
+    padding-right: 1em;
+    background-size: 0.6em;
+  }
+
+  /* except camptocamp full links */
+  a[href^="https://www.camptocamp.org"]::after,
+  a[href^="https://forum.camptocamp.org"]::after,
+  a[href^="https://media.camptocamp.org"]::after
+  {
     content: none;
+  }
+
+  /* also hide the icon when printed */
+  @media print {
+    a[href*="//"]::after
+    {
+      content: none;
+    }
   }
 }

--- a/src/assets/sass/helpers.scss
+++ b/src/assets/sass/helpers.scss
@@ -1,80 +1,78 @@
 @import './variables.scss';
 
-.has-hover-background:hover{
-    background: $hover-background;
+.has-hover-background:hover {
+  background: $hover-background;
 }
 
 // force nowrap
-.is-nowrap{
-    white-space: nowrap;
+.is-nowrap {
+  white-space: nowrap;
 }
 
 // Force a inline element to nowrap, and ellipse overflow
-.is-ellipsed{
+.is-ellipsed {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+@media screen and (min-width: $tablet) {
+  .is-ellipsed-tablet {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+  }
 }
 
-
-@media screen and (min-width: $tablet) {
-    .is-ellipsed-tablet{
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-    }
-}
-
-.has-cursor-pointer{
-    cursor:pointer;
+.has-cursor-pointer {
+  cursor: pointer;
 }
 
 .card-icon {
-    color: $text;
+  color: $text;
 }
 
 .has-text-secondary {
-    color: $secondary;
+  color: $secondary;
 }
 
 .has-background-secondary {
-    background-color: $secondary;
+  background-color: $secondary;
 }
 
 .has-text-normal {
-    color: $text;
+  color: $text;
 }
 
 .has-rounded-corner {
-    border-radius: $radius;
+  border-radius: $radius;
 }
 
 @media print {
-    /* print styles go here */
+  /* print styles go here */
 
-    /* Printing from Firefox with content display:flex will print only the first page.
+  /* Printing from Firefox with content display:flex will print only the first page.
     https://bugzilla.mozilla.org/show_bug.cgi?id=1241323
     */
-    .is-block-print {
-        display:block !important;
-    }
+  .is-block-print {
+    display: block !important;
+  }
 
-    .no-print {
-        display: none!important;
-    }
+  .no-print {
+    display: none !important;
+  }
 
-    .has-background-white-print {
-        background-color: white!important;
-    }
+  .has-background-white-print {
+    background-color: white !important;
+  }
 
-    .box {
-        padding: 0;
-        box-shadow: none;
-        border-bottom: 1px solid lightGrey;
-    }
+  .box {
+    padding: 0;
+    box-shadow: none;
+    border-bottom: 1px solid lightGrey;
+  }
 
-    .is-12-print{
-        width: 100%!important;
-    }
-
+  .is-12-print {
+    width: 100% !important;
+  }
 }

--- a/src/assets/sass/main.scss
+++ b/src/assets/sass/main.scss
@@ -1,5 +1,6 @@
 @import './variables.scss';
 @import './scrollbar.scss';
+@import './external-links.scss';
 
 // with bulma 0.8.0, buttons are now 2.5em high. Use the following lines to restore previous behaviour.
 $control-border-width: 1px;


### PR DESCRIPTION
Adds an icon after external links in order to better identify them.
Especially useful when external links are inside a route description
![image](https://user-images.githubusercontent.com/127776/91724156-2c122180-eb9d-11ea-84b2-f38d0eee1cf5.png)
