### PR TITLE
Update photon.js

### DIFF
--- a/src/js/apis/photon.js
+++ b/src/js/apis/photon.js
@@ -4,7 +4,7 @@
 import BaseApi from '@/js/apis/BaseApi';
 
 function Photon() {
-  BaseApi.call(this, 'https://photon.komoot.de/api/');
+  BaseApi.call(this, 'https://photon.komoot.io/api/');
 }
 
 // inherits prototype


### PR DESCRIPTION
The old URL (`.de` domain) no longer works