### PR TITLE
Hide overflow only for hidden form sections

### DIFF
--- a/src/views/wiki/edition/utils/FormSection.vue
+++ b/src/views/wiki/edition/utils/FormSection.vue
@@ -130,12 +130,9 @@ export default {
     }
   }
 
-  .section-content {
+  .section-content-hidden {
     overflow: hidden;
     transition: max-height 0.3s;
-  }
-
-  .section-content-hidden {
     max-height: 0;
   }
 }


### PR DESCRIPTION
For this issue : https://github.com/c2corg/c2c_ui/issues/1501 ; it's a tricky overflow management for not-hidden form sections that prevented bottom content ( ie search form results ) to be visible.