### PR TITLE
Small fixes for YETI

### DIFF
--- a/src/components/yeti/SubPanelBra.vue
+++ b/src/components/yeti/SubPanelBra.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="yeti-subpanel">
-    <sub-panel-title v-translate>Danger level</sub-panel-title>
+    <sub-panel-title>Danger level</sub-panel-title>
     <div class="columns is-mobile">
       <div class="column">
         <div class="inputs-bra" :class="{ 'inputs-bra-different': bra.isDifferent }">

--- a/src/components/yeti/SubPanelCourse.vue
+++ b/src/components/yeti/SubPanelCourse.vue
@@ -111,6 +111,8 @@
 </template>
 
 <script>
+import { format } from 'date-fns';
+
 import FeaturesList from '@/components/yeti/FeaturesList.vue';
 import SubPanelTitle from '@/components/yeti/SubPanelTitle.vue';
 import ol from '@/js/libs/ol';
@@ -220,8 +222,8 @@ export default {
     },
 
     setFilename(ext) {
-      let date = this.$moment.parseDate(new Date());
-      return date.format('YYYY-MM-DD_HH-mm-ss') + ext;
+      let date = format(new Date(), 'yyyy-MM-dd_HH-mm-ss');
+      return date + ext;
     },
   },
 };

--- a/src/components/yeti/SubPanelCourse.vue
+++ b/src/components/yeti/SubPanelCourse.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="yeti-subpanel">
-    <sub-panel-title v-translate>Route</sub-panel-title>
+    <sub-panel-title>Route</sub-panel-title>
     <div v-if="features.length">
       <div class="columns is-mobile">
         <div class="column">
@@ -39,7 +39,7 @@
         <p class="yetiform-info is-italic is-marginless" v-translate>Lines chunks</p>
         <features-list :features="features" :map="map" />
       </div>
-      <sub-panel-title v-translate>Export</sub-panel-title>
+      <sub-panel-title>Export</sub-panel-title>
       <div class="columns is-vcentered is-mobile">
         <div class="column">
           <ul class="form-export">

--- a/src/components/yeti/SubPanelMethods.vue
+++ b/src/components/yeti/SubPanelMethods.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="yeti-subpanel">
-    <sub-panel-title v-translate>Methods</sub-panel-title>
+    <sub-panel-title>Methods</sub-panel-title>
     <div class="columns is-mobile yetitabs">
       <div v-for="item of Object.keys(methods)" :key="item" class="column yetitab">
         <div class="control yetitab-control" :class="{ 'yetitab-control--selected': method.type === item }">

--- a/src/components/yeti/SubPanelTitle.vue
+++ b/src/components/yeti/SubPanelTitle.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="columns is-mobile">
     <div class="column">
-      <h2 class="title is-3">
+      <h2 class="title is-3" v-translate>
         <slot></slot>
       </h2>
     </div>


### PR DESCRIPTION
It seems that moment was removed in January, and I was testing on a branch from december, so I didn't detect that before. So, replaced with date-fns.

Also, `v-translate` on slotted elements used to work well, but seems broken now. Fixed also.
