### PR TITLE
Toolbox is displayed last on mobile

### DIFF
--- a/src/assets/sass/document-layout.scss
+++ b/src/assets/sass/document-layout.scss
@@ -1,0 +1,53 @@
+@import './variables.scss';
+
+// a kind-of-hacky layout so that for documents, toolbox is displayed last on mobile
+// cannot be done using bulma's columns and column classes...
+.two-columns-doc {
+  display: flex;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.75rem;
+
+  & > div {
+    margin: 0.75rem;
+
+    &:first-child {
+      max-width: 25%;
+      flex-basis: 25%;
+    }
+
+    &:last-child {
+      flex-basis: 75%;
+    }
+  }
+
+  .two-columns-last {
+    order: 99;
+  }
+}
+
+@media screen and (max-width: $tablet) {
+  .two-columns-doc {
+    flex-direction: column;
+    margin: 0;
+
+    & > div {
+      display: contents;
+    }
+
+    .two-columns-last {
+      margin-top: 0.75rem;
+    }
+  }
+}
+
+@media print {
+  .two-columns-doc {
+    flex-direction: column;
+    margin: 0;
+
+    & > div {
+      display: contents;
+    }
+  }
+}

--- a/src/assets/sass/helpers.scss
+++ b/src/assets/sass/helpers.scss
@@ -51,13 +51,6 @@
 @media print {
   /* print styles go here */
 
-  /* Printing from Firefox with content display:flex will print only the first page.
-    https://bugzilla.mozilla.org/show_bug.cgi?id=1241323
-    */
-  .is-block-print {
-    display: block !important;
-  }
-
   .no-print {
     display: none !important;
   }

--- a/src/assets/sass/main.scss
+++ b/src/assets/sass/main.scss
@@ -50,3 +50,5 @@ $button-padding-horizontal: 0.75em;
 @import '~bulma-switch';
 //
 @import './helpers.scss';
+//
+@import './document-layout.scss';

--- a/src/views/document/AreaView.vue
+++ b/src/views/document/AreaView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns">
-      <div class="column is-3">
+    <div v-if="document" class="two-columns-doc">
+      <div>
         <div class="box">
           <field-view :document="document" :field="fields.area_type" />
         </div>
@@ -10,7 +10,7 @@
         <tool-box :document="document" />
       </div>
 
-      <div class="column is-9">
+      <div>
         <div class="box" v-if="document.cooked.summary || document.cooked.description">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.description" />

--- a/src/views/document/ArticleView.vue
+++ b/src/views/document/ArticleView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns is-block-print">
-      <div class="column is-3 is-12-print">
+    <div v-if="document" class="two-columns-doc">
+      <div>
         <div class="box">
           <activities-field :document="document" />
           <field-view :document="document" :field="fields.categories" />
@@ -12,9 +12,9 @@
           </label-value>
         </div>
 
-        <tool-box :document="document" v-if="!$screen.isMobile" />
+        <tool-box :document="document" />
       </div>
-      <div class="column is-9 is-12-print">
+      <div>
         <div class="box">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.description" hide-title />

--- a/src/views/document/BookView.vue
+++ b/src/views/document/BookView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns is-block-print">
-      <div class="column is-3">
+    <div v-if="document" class="two-columns-doc">
+      <div>
         <div class="box">
           <activities-field :document="document" />
           <field-view :document="document" :field="fields.author" />
@@ -18,7 +18,7 @@
         <tool-box :document="document" />
       </div>
 
-      <div class="column is-9">
+      <div>
         <div class="box">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.description" hide-title />

--- a/src/views/document/ImageView.vue
+++ b/src/views/document/ImageView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns">
-      <div class="column is-3">
+    <div v-if="document" class="two-columns-doc">
+      <div>
         <div class="box">
           <activities-field v-if="document.activities && document.activities.length" :document="document" />
 
@@ -33,7 +33,7 @@
         <tool-box :document="document" />
       </div>
 
-      <div class="column is-9">
+      <div>
         <div class="box is-paddingless">
           <a :href="getOriginalImageUrl(document)">
             <img class="main-image" :src="getBigImageUrl(document)" />

--- a/src/views/document/OutingView.vue
+++ b/src/views/document/OutingView.vue
@@ -4,13 +4,13 @@
 
     <images-box v-if="document" :document="document" />
 
-    <div v-if="document" class="columns is-multiline is-block-print">
-      <div class="column is-3 no-print">
+    <div v-if="document" class="two-columns-doc">
+      <div class="no-print">
         <map-box :document="document" />
         <tool-box :document="document" />
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div>
         <div class="box">
           <div v-for="route of document.associations.routes" :key="route.document_id">
             <pretty-route-link :route="route" hide-area hide-orientation />

--- a/src/views/document/RouteView.vue
+++ b/src/views/document/RouteView.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns is-block-print">
-      <div class="column is-3 no-print">
+    <div v-if="document" class="two-columns-doc">
+      <div class="no-print">
         <map-box :document="document" @has-protection-area="hasProtectionArea = true" />
         <tool-box :document="document" />
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div>
         <!-- CONTENT -->
 
         <div class="box">

--- a/src/views/document/WaypointView.vue
+++ b/src/views/document/WaypointView.vue
@@ -8,13 +8,13 @@
       />
     </document-view-header>
 
-    <div v-if="document" class="columns">
-      <div class="column is-3 no-print">
+    <div v-if="document" class="two-columns-doc">
+      <div class="no-print">
         <map-box :document="document" />
         <tool-box :document="document" />
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div>
         <div class="box">
           <div class="columns is-multiline">
             <div class="column is-4">

--- a/src/views/document/XreportView.vue
+++ b/src/views/document/XreportView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section has-background-white-print">
     <document-view-header :document="document" :version="version" :promise="promise" />
-    <div v-if="document" class="columns is-block-print">
-      <div class="column is-3 is-12-print">
+    <div v-if="document" class="two-columns-doc">
+      <div>
         <div class="box">
           <event-activity-field :document="document" />
           <label-value v-if="document.author" :label="$gettext('contributor')">
@@ -32,7 +32,7 @@
         <tool-box :document="document" />
       </div>
 
-      <div class="column is-9 is-12-print">
+      <div>
         <div class="box">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.description" />

--- a/src/views/document/utils/boxes/ToolBox.vue
+++ b/src/views/document/utils/boxes/ToolBox.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="box no-print">
+  <div class="box no-print two-columns-last">
     <associated-documents :document="document" />
 
     <div class="has-text-centered" v-if="isNormalView && available_langs.length">


### PR DESCRIPTION
Kind of hacky, but working...
Bulma's columns cannot be used for this, so rely on some specific classes. The trick is use display: contents to skip a hierarchy level.

I applied it on every view when seems applicable (e.g. not on user profile) and tested print view. Might be worth to do some checks on your side too.

Fixes #1756 