### PR TITLE
Replace Twitter by Instagram

### DIFF
--- a/src/components/generics/icons/IconInstagram.vue
+++ b/src/components/generics/icons/IconInstagram.vue
@@ -1,0 +1,21 @@
+<template>
+  <span>
+    <!-- hack to be able to apply gradient on font awesome 5 icons: https://stackoverflow.com/questions/47800574/gradient-over-instagram-svg-of-fontawesome-5 -->
+    <svg width="0" height="0">
+      <radialGradient id="rg" r="150%" cx="30%" cy="107%">
+        <stop stop-color="#fdf497" offset="0" />
+        <stop stop-color="#fdf497" offset="0.05" />
+        <stop stop-color="#fd5949" offset="0.45" />
+        <stop stop-color="#d6249f" offset="0.6" />
+        <stop stop-color="#285AEB" offset="0.9" />
+      </radialGradient>
+    </svg>
+    <fa-icon :icon="['fab', 'instagram']" class="instagram-icon" />
+  </span>
+</template>
+
+<style lang="scss" scoped>
+.instagram-icon * {
+  fill: url(#rg);
+}
+</style>

--- a/src/js/vue-plugins/font-awesome-config.js
+++ b/src/js/vue-plugins/font-awesome-config.js
@@ -3,7 +3,6 @@ import { faCreativeCommons } from '@fortawesome/free-brands-svg-icons/faCreative
 import { faFacebook } from '@fortawesome/free-brands-svg-icons/faFacebook';
 import { faGoogle } from '@fortawesome/free-brands-svg-icons/faGoogle';
 import { faInstagram } from '@fortawesome/free-brands-svg-icons/faInstagram';
-import { faTwitter } from '@fortawesome/free-brands-svg-icons/faTwitter';
 import { faCircle as faCircleRegular } from '@fortawesome/free-regular-svg-icons/faCircle';
 import { faClock as faClockRegular } from '@fortawesome/free-regular-svg-icons/faClock';
 import { faHourglass as faHourglassRegular } from '@fortawesome/free-regular-svg-icons/faHourglass';
@@ -327,7 +326,6 @@ export default function install(Vue) {
     faCreativeCommons,
     faFacebook,
     faGoogle,
-    faTwitter,
     faInstagram
   );
 

--- a/src/js/vue-plugins/font-awesome-config.js
+++ b/src/js/vue-plugins/font-awesome-config.js
@@ -2,6 +2,7 @@ import { library } from '@fortawesome/fontawesome-svg-core';
 import { faCreativeCommons } from '@fortawesome/free-brands-svg-icons/faCreativeCommons';
 import { faFacebook } from '@fortawesome/free-brands-svg-icons/faFacebook';
 import { faGoogle } from '@fortawesome/free-brands-svg-icons/faGoogle';
+import { faInstagram } from '@fortawesome/free-brands-svg-icons/faInstagram';
 import { faTwitter } from '@fortawesome/free-brands-svg-icons/faTwitter';
 import { faCircle as faCircleRegular } from '@fortawesome/free-regular-svg-icons/faCircle';
 import { faClock as faClockRegular } from '@fortawesome/free-regular-svg-icons/faClock';
@@ -326,7 +327,8 @@ export default function install(Vue) {
     faCreativeCommons,
     faFacebook,
     faGoogle,
-    faTwitter
+    faTwitter,
+    faInstagram
   );
 
   Vue.component('FaIcon', FontAwesomeIcon);

--- a/src/views/SideMenu.vue
+++ b/src/views/SideMenu.vue
@@ -80,7 +80,7 @@
       <div class="columns is-gapless has-text-centered is-mobile menu-socials">
         <div class="column">
           <a href="https://www.instagram.com/camptocamp_org/" title="Instagram">
-            <fa-icon :icon="['fab', 'instagram']" class="instagram-icon" />
+            <icon-instagram class="instagram-icon" />
           </a>
         </div>
         <div class="column">
@@ -213,13 +213,7 @@ aside {
     font-size: 30px;
   }
 
-  .instagram-icon,
-  &:hover {
-    color: #e1306c; // instagram color
-  }
-
-  .facebook-icon,
-  &:hover {
+  .facebook-icon {
     color: #6d8bc9; //facebook color
   }
 

--- a/src/views/SideMenu.vue
+++ b/src/views/SideMenu.vue
@@ -80,7 +80,7 @@
       <div class="columns is-gapless has-text-centered is-mobile menu-socials">
         <div class="column">
           <a href="https://www.instagram.com/camptocamp_org/" title="Instagram">
-            <fa-icon :icon="['fab', 'twitter']" class="instagram-icon" />
+            <fa-icon :icon="['fab', 'instagram']" class="instagram-icon" />
           </a>
         </div>
         <div class="column">

--- a/src/views/SideMenu.vue
+++ b/src/views/SideMenu.vue
@@ -79,12 +79,12 @@
 
       <div class="columns is-gapless has-text-centered is-mobile menu-socials">
         <div class="column">
-          <a href="https://twitter.com/camptocamporg" title="twitter">
-            <fa-icon :icon="['fab', 'twitter']" class="twitter-icon" />
+          <a href="https://www.instagram.com/camptocamp_org/" title="Instagram">
+            <fa-icon :icon="['fab', 'twitter']" class="instagram-icon" />
           </a>
         </div>
         <div class="column">
-          <a href="https://www.facebook.com/camptocamp.org/" title="facebook">
+          <a href="https://www.facebook.com/camptocamp.org/" title="Facebook">
             <fa-icon :icon="['fab', 'facebook']" class="facebook-icon" />
           </a>
         </div>
@@ -207,15 +207,15 @@ aside {
     margin-right: calc((200px - 160px) / 2);
   }
 
-  .twitter-icon,
+  .instagram-icon,
   .facebook-icon,
   .donate-icon {
     font-size: 30px;
   }
 
-  .twitter-icon,
+  .instagram-icon,
   &:hover {
-    color: #4198fb; // twitter color
+    color: #e1306c; // instagram color
   }
 
   .facebook-icon,


### PR DESCRIPTION
I did not manage to turn the icon from Twitter into the one from Instagram.

I want to use this one: https://fontawesome.com/v5.15/icons/instagram?style=brands
I tried to just write 
     `<fa-icon :icon="['fab', 'instagram']" class="instagram-icon" />`
on line 83, but somehow it does not work ... do you know why ?

Currently [this one is used for facebook](https://fontawesome.com/v5.15/icons/facebook?style=brands) and [this one was used for twitter](https://fontawesome.com/v5.15/icons/twitter?style=brands).