### PR TITLE
Use API sorting feature in UI 

### DIFF
--- a/src/assets/font-awesome-custom/js/miscs/index.js
+++ b/src/assets/font-awesome-custom/js/miscs/index.js
@@ -2,8 +2,10 @@
 
 import drill from "./drill"
 import paragliding from "./paragliding"
+import sort from "./sort"
 
 export {
     drill,
-    paragliding
+    paragliding,
+    sort
 }

--- a/src/assets/font-awesome-custom/js/miscs/sort.js
+++ b/src/assets/font-awesome-custom/js/miscs/sort.js
@@ -1,0 +1,14 @@
+// Auto-generated file by generate-icons.js
+
+
+export default {
+  prefix: 'miscs',
+  iconName: 'sort',
+  icon: [
+    14,
+    14,
+    [],
+    "",
+    'M4 .6L.3 4.3a1 1 0 001.4 1.4L3 4.4V12a1 1 0 102 0V4.4l1.3 1.3a1 1 0 001.4-1.4L4 .6zm6 .4a1 1 0 00-1 1v7.6L7.7 8.3a1 1 0 00-1.4 1.4l3.7 3.7 3.7-3.7a1 1 0 00-1.4-1.4L11 9.6V2c0-.6-.4-1-1-1z'
+  ]
+}

--- a/src/assets/font-awesome-custom/svg/miscs/sort.svg
+++ b/src/assets/font-awesome-custom/svg/miscs/sort.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
+  <path style="-inkscape-stroke:none" d="M4 .6L.3 4.3a1 1 0 001.4 1.4L3 4.4V12a1 1 0 102 0V4.4l1.3 1.3a1 1 0 001.4-1.4L4 .6zm6 .4a1 1 0 00-1 1v7.6L7.7 8.3a1 1 0 00-1.4 1.4l3.7 3.7 3.7-3.7a1 1 0 00-1.4-1.4L11 9.6V2c0-.6-.4-1-1-1z" color="#000"/>
+</svg>

--- a/src/js/constants/documentsProperties.json
+++ b/src/js/constants/documentsProperties.json
@@ -399,7 +399,6 @@
         "properties": {
           "url": "dhei",
           "activities": [
-            "hiking",
             "rock_climbing",
             "via_ferrata",
             "snow_ice_mixed",

--- a/src/js/constants/fieldsProperties.json
+++ b/src/js/constants/fieldsProperties.json
@@ -15,7 +15,8 @@
     "parent": "locales"
   },
   "access_time": {
-    "values": "access_times"
+    "values": "access_times",
+    "sortable": true
   },
   "activities": {
     "values": "activities",
@@ -37,7 +38,8 @@
     "values": "aid_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "133323#aid"
+    "helper": "133323#aid",
+    "sortable": true
   },
   "anonymous": {
     "type": "boolean",
@@ -153,15 +155,18 @@
   },
   "climbing_rating_max": {
     "values": "climbing_ratings",
-    "i18n": false
+    "i18n": false,
+    "sortable": true
   },
   "climbing_rating_median": {
     "values": "climbing_ratings",
-    "i18n": false
+    "i18n": false,
+    "sortable": true
   },
   "climbing_rating_min": {
     "values": "climbing_ratings",
-    "i18n": false
+    "i18n": false,
+    "sortable": true
   },
   "climbing_styles": {
     "values": "climbing_styles",
@@ -236,7 +241,8 @@
     "type": "number",
     "min": 0,
     "max": 9000,
-    "unit": "m"
+    "unit": "m",
+    "sortable": true
   },
   "elevation_access": {
     "type": "number",
@@ -255,7 +261,8 @@
     "type": "number",
     "min": 0,
     "max": 9000,
-    "unit": "m"
+    "unit": "m",
+    "sortable": true
   },
   "elevation_min": {
     "type": "number",
@@ -274,13 +281,15 @@
     "values": "engagement_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "133323#engagement"
+    "helper": "133323#engagement",
+    "sortable": true
   },
   "equipment_rating": {
     "values": "equipment_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "133323#equipment"
+    "helper": "133323#equipment",
+    "sortable": true
   },
   "equipment_ratings": {
     "values": "equipment_ratings",
@@ -300,7 +309,8 @@
     "values": "exposition_rock_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "133323#exposition"
+    "helper": "133323#exposition",
+    "sortable": true
   },
   "exposure_time": {
     "type": "number",
@@ -358,7 +368,8 @@
     "values": "global_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "133323#global-rating"
+    "helper": "133323#global-rating",
+    "sortable": true
   },
   "ground_types": {
     "values": "ground_types",
@@ -388,7 +399,8 @@
     "min": 0,
     "max": 3000,
     "unit": "m",
-    "helper": "1063027#height-diff_difficulties"
+    "helper": "1063027#height-diff_difficulties",
+    "sortable": true
   },
   "height_diff_down": {
     "type": "number",
@@ -402,7 +414,8 @@
     "min": 0,
     "max": 9000,
     "unit": "m",
-    "helper": "1063027#height-diff_up"
+    "helper": "1063027#height-diff_up",
+    "sortable": true
   },
   "height_max": {
     "type": "number",
@@ -432,7 +445,8 @@
     "values": "hiking_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "106859#hiking-rating"
+    "helper": "106859#hiking-rating",
+    "sortable": true
   },
   "hut_comment": {
     "type": "markdown",
@@ -455,7 +469,8 @@
     "values": "ice_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "106871#ice-rating"
+    "helper": "106871#ice-rating",
+    "sortable": true
   },
   "image_categories": {
     "name": "categories",
@@ -485,13 +500,15 @@
     "values": "global_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "107675#labande-global_rating"
+    "helper": "107675#labande-global_rating",
+    "sortable": true
   },
   "labande_ski_rating": {
     "values": "labande_ski_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "107675#labande-ski-rating"
+    "helper": "107675#labande-ski-rating",
+    "sortable": true
   },
   "langs": {
     "values": "langs",
@@ -530,7 +547,8 @@
     "values": "mixed_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "106871#mixed-rating"
+    "helper": "106871#mixed-rating",
+    "sortable": true
   },
   "modifications": {
     "type": "markdown",
@@ -545,7 +563,8 @@
     "values": "mtb_down_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "922056#mtb-down_rating"
+    "helper": "922056#mtb-down_rating",
+    "sortable": true
   },
   "mtb_height_diff_portages": {
     "type": "number",
@@ -569,7 +588,8 @@
     "values": "mtb_up_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "922056#mtb-up_rating"
+    "helper": "922056#mtb-up_rating",
+    "sortable": true
   },
   "name": {
     "disabled": true
@@ -705,19 +725,22 @@
     "values": "risk_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "133323#objective-danger"
+    "helper": "133323#objective-danger",
+    "sortable": true
   },
   "rock_free_rating": {
     "values": "climbing_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "133323#rock-free"
+    "helper": "133323#rock-free",
+    "sortable": true
   },
   "rock_required_rating": {
     "values": "climbing_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "133323#rock-required"
+    "helper": "133323#rock-required",
+    "sortable": true
   },
   "rock_types": {
     "values": "rock_types",
@@ -735,7 +758,8 @@
     "type": "number",
     "min": 0,
     "max": 500000,
-    "unit": "m"
+    "unit": "m",
+    "sortable": true
   },
   "route_study": {
     "type": "markdown",
@@ -775,13 +799,15 @@
     "values": "exposition_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "107675#ski-exposition"
+    "helper": "107675#ski-exposition",
+    "sortable": true
   },
   "ski_rating": {
     "values": "ski_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "107675#ski-rating"
+    "helper": "107675#ski-rating",
+    "sortable": true
   },
   "slackline_anchor1": {
     "type": "markdown",
@@ -800,13 +826,17 @@
     "type": "number",
     "min": 0,
     "max": 9000,
-    "unit": "m"
+    "unit": "m",
+    "sortable": false,
+    "_comment": "not sortable: api responds 500"
   },
   "slackline_length_min": {
     "type": "number",
     "min": 0,
     "max": 9000,
-    "unit": "m"
+    "unit": "m",
+    "sortable": false,
+    "_comment": "not sortable: api responds 500"
   },
   "slackline_type": {
     "values": "slackline_types"
@@ -840,7 +870,8 @@
     "values": "snowshoe_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "239491#snowshoe-rating"
+    "helper": "239491#snowshoe-rating",
+    "sortable": true
   },
   "summary": {
     "type": "markdown",
@@ -884,7 +915,8 @@
     "values": "via_ferrata_ratings",
     "queryMode": "valuesRangeSlider",
     "i18n": false,
-    "helper": "925306#via-ferrata_rating"
+    "helper": "925306#via-ferrata_rating",
+    "sortable": true
   },
   "waypoint_type": {
     "values": "waypoint_types"

--- a/src/js/vue-plugins/font-awesome-config.js
+++ b/src/js/vue-plugins/font-awesome-config.js
@@ -85,6 +85,8 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons/faSearch';
 import { faShareAlt } from '@fortawesome/free-solid-svg-icons/faShareAlt';
 import { faSignInAlt } from '@fortawesome/free-solid-svg-icons/faSignInAlt';
 import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons/faSignOutAlt';
+import { faSortAmountDown } from '@fortawesome/free-solid-svg-icons/faSortAmountDown';
+import { faSortAmountDownAlt } from '@fortawesome/free-solid-svg-icons/faSortAmountDownAlt';
 import { faSortAmountUp } from '@fortawesome/free-solid-svg-icons/faSortAmountUp';
 import { faSquare } from '@fortawesome/free-solid-svg-icons/faSquare';
 import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
@@ -121,6 +123,7 @@ import activityVia_ferrata from '@/assets/font-awesome-custom/js/activity/via_fe
 import documentTypeOuting from '@/assets/font-awesome-custom/js/document-type/outing';
 import drill from '@/assets/font-awesome-custom/js/miscs/drill';
 import paragliding from '@/assets/font-awesome-custom/js/miscs/paragliding';
+import sort from '@/assets/font-awesome-custom/js/miscs/sort';
 import qualityDraft from '@/assets/font-awesome-custom/js/quality/draft';
 import qualityEmpty from '@/assets/font-awesome-custom/js/quality/empty';
 import qualityFine from '@/assets/font-awesome-custom/js/quality/fine';
@@ -162,8 +165,9 @@ import waypointwebcam from '@/assets/font-awesome-custom/js/waypoint/webcam';
 // registered globally
 export default function install(Vue) {
   library.add(
-    paragliding,
     drill,
+    paragliding,
+    sort,
 
     documentTypeOuting,
 
@@ -298,6 +302,8 @@ export default function install(Vue) {
     faShareAlt,
     faSignInAlt,
     faSignOutAlt,
+    faSortAmountDown,
+    faSortAmountDownAlt,
     faSortAmountUp,
     faSquare,
     faStar,

--- a/src/views/documents/DocumentsView.vue
+++ b/src/views/documents/DocumentsView.vue
@@ -16,7 +16,7 @@
               :key="type"
               class="dropdown-item is-size-6"
               :class="{ 'is-active': type === documentType }"
-              :to="{ name: type + 's', query: queryWithoutOffset }"
+              :to="{ name: type + 's', query: queryWithoutOffsetAndSort }"
             >
               <icon-document :document-type="type" />
               <span>&nbsp;{{ getDocumentTypeTitle(type) | uppercaseFirstLetter }}</span>
@@ -87,8 +87,7 @@
             :key="index"
             :class="{
               'is-full-mobile is-half-tablet is-half-desktop is-half-widescreen is-half-fullhd': showMap,
-              'is-full-mobile is-one-third-tablet is-one-third-desktop is-one-quarter-widescreen is-one-quarter-fullhd':
-                !showMap,
+              'is-full-mobile is-one-third-tablet is-one-third-desktop is-one-quarter-widescreen is-one-quarter-fullhd': !showMap,
             }"
             class="column card-container"
             @mouseenter="highlightedDocument = document"
@@ -187,9 +186,10 @@ export default {
         act: this.$route.query.act,
       };
     },
-    queryWithoutOffset() {
+    queryWithoutOffsetAndSort() {
       const result = Object.assign({}, this.$route.query);
       delete result.offset;
+      delete result.sort;
 
       return result;
     },

--- a/src/views/documents/utils/ExportCsvButton.vue
+++ b/src/views/documents/utils/ExportCsvButton.vue
@@ -1,10 +1,11 @@
 <template>
-  <button class="button is-primary" @click="exportCsv">
+  <button class="button is-primary is-size-7-mobile" @click="exportCsv">
     <fa-icon icon="file-download"></fa-icon>
     <span class="is-hidden-touch">&nbsp;</span>
     <span class="is-hidden-touch" v-translate>Export to CSV</span>
   </button>
 </template>
+
 <script>
 export default {
   methods: {
@@ -14,4 +15,3 @@ export default {
   },
 };
 </script>
-<style lang="scss" scoped></style>

--- a/src/views/documents/utils/QueryItemSliderLabel.vue
+++ b/src/views/documents/utils/QueryItemSliderLabel.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="columns is-mobile">
       <!--level must be in a single element to remove bottim margin : TODO remove ugly hack -->
-      <div class="column query-bound-value-left">
+      <div class="column query-bound-value-left is-nowrap">
         <span v-if="field.i18n">{{ $gettext(value[0], field.i18nContext) | uppercaseFirstLetter }}</span>
         <span v-else>{{ value[0] }}</span>
         <span v-if="field.unit">&nbsp;{{ field.unit }}</span>
@@ -16,7 +16,7 @@
       <div class="column query-label" :class="{ 'is-narrow': !field.i18n, 'is-4': field.i18n }">
         {{ $gettext(field.name) | uppercaseFirstLetter }}
       </div>
-      <div class="column query-bound-value-right">
+      <div class="column query-bound-value-right is-nowrap">
         <span v-if="field.i18n">{{ $gettext(value[1], field.i18nContext) | uppercaseFirstLetter }}</span>
         <span v-else>{{ value[1] }}</span>
         <span v-if="field.unit">&nbsp;{{ field.unit }}</span>

--- a/src/views/documents/utils/QueryItems.vue
+++ b/src/views/documents/utils/QueryItems.vue
@@ -379,6 +379,11 @@ export default {
 <style scoped lang="scss">
 .query-items-filters {
   margin-bottom: 0.5rem;
+  font-size: 0;
+
+  > div {
+    font-size: 1rem;
+  }
 }
 
 .title-input {

--- a/src/views/documents/utils/QueryItems.vue
+++ b/src/views/documents/utils/QueryItems.vue
@@ -1,15 +1,20 @@
 <template>
   <div class="query-items">
-    <div>
-      <query-item v-if="fields.title" :field="fields.title" class="title-input is-hidden-mobile" hide-label />
+    <div class="query-items-filters">
+      <query-item
+        v-if="fields.title"
+        :field="fields.title"
+        class="title-input is-hidden-mobile query-item-component"
+        hide-label
+      />
 
       <dropdown-button
         v-for="category of categorizedFields"
         :key="category.name"
-        class="category-button"
+        class="query-item-component"
         :disabled="category.fields.length === 0"
       >
-        <span slot="button" class="button is-small-mobile" :disabled="category.fields.length === 0">
+        <span slot="button" class="button is-size-7-mobile" :disabled="category.fields.length === 0">
           <fa-icon :icon="$options.categoryIcon[category.name]" />
           <span class="is-hidden-mobile">
             <!-- $gettext('General') -->
@@ -34,15 +39,20 @@
         </div>
       </dropdown-button>
 
+      <query-sort-dropdown
+        v-if="['waypoint', 'route', 'image', 'outing'].includes(documentType)"
+        class="query-item-component"
+      />
+
       <association-query-item
-        class="association-query-item is-hidden-mobile"
+        class="query-item-component is-hidden-mobile"
         :document-types="associations"
         @add="addTag"
       />
-      <load-user-preferences-button class="is-hidden-tablet category-button" />
+      <load-user-preferences-button class="is-hidden-tablet query-item-component" />
       <export-csv-button v-if="listMode" class="is-small-mobile"></export-csv-button>
     </div>
-    <div class="is-hidden-mobile">
+    <div class="query-items-tags is-hidden-mobile">
       <query-tags :documents="tags" @remove="removeTag"></query-tags>
     </div>
   </div>
@@ -53,7 +63,9 @@ import AssociationQueryItem from './AssociationQueryItem';
 import ExportCsvButton from './ExportCsvButton.vue';
 import LoadUserPreferencesButton from './LoadUserPreferencesButton';
 import QueryItem from './QueryItem';
+import QuerySortDropdown from './QuerySortDropdown';
 import QueryTags from './QueryTags';
+import urlMixin from './url-mixin';
 
 import c2c from '@/js/apis/c2c';
 import constants from '@/js/constants';
@@ -190,10 +202,13 @@ export default {
   components: {
     AssociationQueryItem,
     QueryItem,
+    QuerySortDropdown,
     QueryTags,
     ExportCsvButton,
     LoadUserPreferencesButton,
   },
+
+  mixins: [urlMixin],
 
   props: {
     listMode: {
@@ -209,26 +224,6 @@ export default {
   },
 
   computed: {
-    urlActivities() {
-      return (this.$route.query.act ?? '').split(',');
-    },
-
-    urlWaypointTypes() {
-      return (this.$route.query.wtyp ?? '').split(',');
-    },
-
-    fields() {
-      return constants.objectDefinitions[this.documentType].fields;
-    },
-
-    documentType() {
-      // route name are like outings, routes ...
-      // always the document type with a tail "s".
-      // the `.slice(0, -1)` removes this "s"
-      // it also can be outings-stats => the `.split('-')[0]` remove "-stats"
-      return this.$route.name.split('-')[0].slice(0, -1);
-    },
-
     associations() {
       if (this.documentType === 'outing') {
         return ['area', 'route', 'waypoint', 'profile'];
@@ -266,11 +261,7 @@ export default {
               temp.activeCount += 1;
             }
 
-            if (this.documentType === 'waypoint') {
-              if (field.isVisibleForWaypointTypes(this.urlWaypointTypes)) {
-                temp.fields.push(field);
-              }
-            } else if (field.isVisibleForActivities(this.urlActivities)) {
+            if (this.fieldIsVisible(field)) {
               temp.fields.push(field);
             }
           }
@@ -386,6 +377,10 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.query-items-filters {
+  margin-bottom: 0.5rem;
+}
+
 .title-input {
   display: inline-flex;
   margin-bottom: 0 !important;
@@ -396,47 +391,22 @@ export default {
 }
 
 @media screen and (min-width: $tablet) {
-  .query-items {
-    display: flex;
-    flex-direction: column;
-
-    & + div {
-      display: flex;
-    }
-
-    div:last-child {
-      margin-top: 0.3rem;
-    }
-  }
-  .title-input,
-  .category-button {
-    margin-right: 1em;
+  .query-item-component {
+    margin-right: 0.75em;
   }
 }
 
 @media screen and (max-width: $tablet) {
-  .button.is-small-mobile {
-    border-radius: 2px;
-    font-size: 0.7857rem;
+  .query-item-component {
+    margin-right: 0.25em;
   }
 
-  .query-items + div:first-child {
-    position: relative; // important; to force dropdown to be on stick to left
-    display: flex;
-    justify-content: flex-start;
+  .query-items-filters {
+    position: relative; // important, to force drop down on the left
+  }
 
-    .title-input,
-    .category-button {
-      margin-right: 0.5em;
-    }
-
-    .dropdown {
-      position: unset;
-
-      .dropdown-menu {
-        width: 100%;
-      }
-    }
+  .dropdown {
+    position: unset; // important, to force drop down on the left
   }
 }
 </style>

--- a/src/views/documents/utils/QuerySortDropdown.vue
+++ b/src/views/documents/utils/QuerySortDropdown.vue
@@ -1,0 +1,153 @@
+<template>
+  <dropdown-button>
+    <span slot="button" class="button is-size-7-mobile">
+      <fa-icon :icon="['miscs', 'sort']" />
+      <span class="is-hidden-mobile"> &nbsp;{{ $gettext('Sort by') }} </span>
+      <span>&nbsp;</span>
+      <fa-icon icon="angle-down" aria-hidden="true" />
+    </span>
+
+    <div v-if="complexSort">
+      <div class="dropdown-item is-italic" v-translate>You are using a custom sort</div>
+      <div class="dropdown-item">
+        <button class="button" v-translate @click="clear">Reset</button>
+      </div>
+    </div>
+    <div v-else-if="sortableFields.length">
+      <div class="dropdown-item sort-item" v-for="field of sortableFields" :key="field">
+        <span
+          class="has-cursor-pointer is-nowrap sort-label"
+          :class="{ 'has-text-weight-bold': field == sortField }"
+          @click="toggle(field)"
+        >
+          {{ $gettext(field) }}
+        </span>
+        <span v-if="field == sortField" class="has-cursor-pointer">
+          <fa-icon
+            v-if="!reversed"
+            icon="sort-amount-down-alt"
+            @click="setSort('-' + field)"
+            :title="$gettext('ascending sort')"
+          />
+          <fa-icon
+            v-if="reversed"
+            icon="sort-amount-down"
+            @click="setSort(field)"
+            :title="$gettext('descending sort')"
+          />
+        </span>
+        <div v-else class="no-sort-filler" />
+      </div>
+    </div>
+    <div v-else>
+      <div class="dropdown-item is-italic">
+        <span v-if="documentType === 'waypoint'" v-translate>
+          Please select a waypoint type to enable sort feature
+        </span>
+        <span v-translate> Please select an activity to enable sort feature </span>
+      </div>
+    </div>
+  </dropdown-button>
+</template>
+
+<script>
+import urlMixin from './url-mixin';
+
+import constants from '@/js/constants';
+
+export default {
+  mixins: [urlMixin],
+
+  data() {
+    return {
+      sortField: null,
+      reversed: null,
+      complexSort: false,
+      sortableFields: [],
+    };
+  },
+
+  watch: {
+    $route: {
+      handler: 'updateFromRoute',
+      immediate: true,
+    },
+  },
+
+  methods: {
+    setAsComplexSort() {
+      this.sortField = null;
+      this.reversed = null;
+      this.complexSort = true;
+    },
+
+    updateFromRoute() {
+      const sortableFields = [];
+
+      for (const field of Object.values(constants.objectDefinitions[this.documentType].fields)) {
+        if (field.sortable && this.fieldIsVisible(field)) {
+          sortableFields.push(field.name);
+        }
+      }
+
+      this.sortableFields = sortableFields;
+
+      if (!this.$route.query.sort) {
+        this.sortField = null;
+        this.reversed = null;
+        this.complexSort = false;
+        return;
+      }
+
+      if (this.$route.query.sort.includes(',')) {
+        this.setAsComplexSort();
+        return;
+      }
+
+      let sortField = this.$route.query.sort;
+      if (sortField.startsWith('-')) {
+        sortField = sortField.substring(1);
+        this.reversed = true;
+      } else {
+        this.reversed = false;
+      }
+
+      if (!this.sortableFields.includes(sortField)) {
+        this.setAsComplexSort();
+        return;
+      }
+
+      this.complexSort = false;
+      this.sortField = sortField;
+    },
+
+    toggle(field) {
+      this.setSort(this.sortField === field ? undefined : field);
+    },
+
+    clear() {
+      this.setSort(undefined);
+    },
+
+    setSort(field) {
+      const query = Object.assign({}, this.$route.query);
+      query.sort = field;
+      this.$router.push({ query });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.no-sort-filler {
+  width: 20px;
+}
+
+.sort-item {
+  display: flex !important;
+}
+.sort-label {
+  flex-grow: 1;
+  padding-right: 3em;
+}
+</style>

--- a/src/views/documents/utils/url-mixin.js
+++ b/src/views/documents/utils/url-mixin.js
@@ -1,0 +1,39 @@
+import constants from '@/js/constants';
+
+export default {
+  computed: {
+    urlWaypointTypes() {
+      return (this.$route.query.wtyp ?? '').split(',');
+    },
+
+    urlActivities() {
+      return (this.$route.query.act ?? '').split(',');
+    },
+
+    fields() {
+      return constants.objectDefinitions[this.documentType].fields;
+    },
+
+    documentType() {
+      // route name are like outings, routes ...
+      // always the document type with a tail "s".
+      // the `.slice(0, -1)` removes this "s"
+      // it also can be outings-stats => the `.split('-')[0]` remove "-stats"
+      return this.$route.name.split('-')[0].slice(0, -1);
+    },
+  },
+
+  methods: {
+    fieldIsVisible(field) {
+      if (this.documentType === 'waypoint') {
+        if (field.isVisibleForWaypointTypes(this.urlWaypointTypes)) {
+          return true;
+        }
+      } else if (field.isVisibleForActivities(this.urlActivities)) {
+        return true;
+      }
+
+      return false;
+    },
+  },
+};


### PR DESCRIPTION
Generic component for #383

A first try has be done by #911. I have taken a different approach here : 

* The sort tool works for both display: cards and list
* I voluntary keep it very simple: a unique sort key, possibly reversed
  * It corresponds to 95% (from my famous data scientist, the wet finger :smile: ) of usages.
  * having the possibility of more than one key makes the UI way more complex (sorting by "A then B" is not the same as "B then A"). Implementing this UI is very complicated without bad shortcuts, and makes the UI too complex for the 95% above.
* On the same spirit, I tried to display only the most used fields, even if more fields are possible. 

https://c2corg.github.io/c2c_ui/sort-ui/#/routes?act=rock_climbing&sort=-engagement_rating

![image](https://user-images.githubusercontent.com/11915659/122522632-796d5b80-d016-11eb-8446-febaa8bf7d87.png)

For non-technical comments : https://forum.camptocamp.org/t/trier-les-documents/282278
