### PR TITLE
Fix analytics enabling on startup

### DIFF
--- a/src/js/vue-plugins/gdpr.js
+++ b/src/js/vue-plugins/gdpr.js
@@ -11,15 +11,12 @@ export default function install(Vue) {
         let storedValue = this.$localStorage.get('choice');
         // if choice is over a year, consent must be asked again
         if (Date.now() - (storedValue?.date ?? 0) > 1000 * 60 * 60 * 24 * 365) {
+          this.$localStorage.clear();
           storedValue = null;
         }
         this.gdprValue = storedValue;
       } catch (err) {
         this.gdprValue = undefined;
-      }
-
-      if (this.gdprValue?.statistics) {
-        this.$ga.enable();
       }
     },
 

--- a/src/js/vue-plugins/local-storage.js
+++ b/src/js/vue-plugins/local-storage.js
@@ -5,7 +5,11 @@
 
 function LocalStorageItem(key) {
   this.key = key;
-  this.data_ = JSON.parse(window.localStorage.getItem(key) ?? '{}');
+  try {
+    this.data_ = JSON.parse(window.localStorage.getItem(key) ?? '{}');
+  } catch (err) {
+    this.data_ = {};
+  }
 }
 
 LocalStorageItem.prototype.commit_ = function () {
@@ -68,6 +72,12 @@ export default function install(Vue) {
       // find another way. Maybe this in created() :
       // this.$localStorage
       return localStorage.getItem(`${this.$options.name}.preferences`);
+    },
+    clear() {
+      if (!this.$options.name) {
+        throw new Error('Please set name property of your componenent');
+      }
+      localStorage.removeItem(`${this.$options.name}.preferences`);
     },
   });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -29,21 +29,14 @@ Vue.config.silent = false;
 Vue.use(localStorage); // First, vm.$localStorage property
 
 Vue.use(gdpr);
-
-let enableAnalytics = false;
-try {
-  enableAnalytics = JSON.parse(window.localStorage.getItem('Gdpr.preferences', '{}')).choice?.statistics || false;
-} catch (err) {
-  window.localStorage.removeItem('Gdpr.preferences');
-}
 Vue.use(VueAnalytics, {
   id: config.googleAnalyticsKey,
-  disabled: !enableAnalytics,
-  /*debug: {
-    enabled: true,
-    trace: true,
-    sendHitTask: true,
-  },*/
+  disabled: true,
+  beforeFirstHit() {
+    if (Vue.prototype.$gdpr.gdprValue?.statistics) {
+      Vue.prototype.$ga.enable();
+    }
+  },
   router,
   autoTracking: {
     // do not send updates if query parameter has changed

--- a/src/main.js
+++ b/src/main.js
@@ -28,15 +28,22 @@ Vue.config.silent = false;
 
 Vue.use(localStorage); // First, vm.$localStorage property
 
-// Google analytics
+Vue.use(gdpr);
+
+let enableAnalytics = false;
+try {
+  enableAnalytics = JSON.parse(window.localStorage.getItem('Gdpr.preferences', '{}')).choice?.statistics || false;
+} catch (err) {
+  window.localStorage.removeItem('Gdpr.preferences');
+}
 Vue.use(VueAnalytics, {
   id: config.googleAnalyticsKey,
-  disabled: true,
-  // debug: {
-  //   enabled: true, // default value
-  //   trace: true, // default value
-  //   sendHitTask: true, // default value
-  // },
+  disabled: !enableAnalytics,
+  /*debug: {
+    enabled: true,
+    trace: true,
+    sendHitTask: true,
+  },*/
   router,
   autoTracking: {
     // do not send updates if query parameter has changed
@@ -71,7 +78,6 @@ Vue.use(screen); // screen reactives properties
 Vue.use(stripMarkdown); // stripMarkdown filter
 Vue.use(upperCaseFirstLetter); // upperCaseFirstLetter filter
 Vue.use(user); // vm.$user property
-Vue.use(gdpr);
 
 new Vue({
   router,


### PR DESCRIPTION
Because Gdpr plugin `created` function was called before configuring vue-analytics plugin (don't know exactly why...), if the user acceped ga cookies, it was enabled, then disabled again.
This fix ensures to read configuration from stored cookies to enable or disable plugin, although it requires to directly read cookie information.

Not also that we should someday upgrade vue-analytics plugin to vue-gtag...

Fixes #2062 