### PR TITLE
Add user category icons next to the contributor link

### DIFF
--- a/src/views/document/utils/field-viewers/ProfilesLinks.vue
+++ b/src/views/document/utils/field-viewers/ProfilesLinks.vue
@@ -6,6 +6,7 @@
       :key="profile.document_id"
       :document="profile"
       class="user-link-label"
+      :class="profile.categories"
       uppercase-first-letter
     />
   </span>
@@ -25,5 +26,8 @@ export default {
 <style scoped>
 .user-link-label:not(:last-child)::after {
   content: ', ';
+}
+.mountain_guide {
+  color:red;
 }
 </style>


### PR DESCRIPTION
That would be interesting to make contributors categories (guides, instructors, hut keepers, avalanche_forecaster, etc.) more explicit especially in outings. For instance by adding a small icon next to the contributor names.

I don't really know how to do it yet and would appreciate any input :P 

I though of adding classes to the contributor links and having CSS selectors such as:
```
mountain_guide:after {
  content: url('some_icon_lnk');
}
```
Would this make sense?
Should this uses png icons? SVG icons?
The suggested change seems to only impact the contributor links in the outings (not in the versions pages nor in the route pages nor in the cards nor in outings lists etc.).
![Screenshot from 2021-07-08 22-08-06](https://user-images.githubusercontent.com/1192331/124985332-922bc880-e03a-11eb-958a-9a61dc61c989.png)
