### PR TITLE
Fine tune events on CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,7 @@
 name: Generate changelog
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 name: Continuous integration
 
 on:
-  push:
+  pull_request:
     branches:
       - '**'
+  push:
+    branches: [ master ]
     tags:
       - '**'
 


### PR DESCRIPTION
* Add a workflow_dispatch on changelog
* Add CI on PR (it will be run against the merged version of the code, that's way more relevant
* Remove CI on all pushes (overkill, and add some noise on PR), but keep it at pushes on `master`