### PR TITLE
Print a list of documents in PDF

### DIFF
--- a/src/assets/sass/helpers.scss
+++ b/src/assets/sass/helpers.scss
@@ -62,6 +62,15 @@
     display: none !important;
   }
 
+  .print-image .no-print.image-box {
+    display: block !important;
+  }
+
+  .print-image .no-print.image-box .swiper-wrapper {
+    flex-wrap: wrap !important;
+    justify-content: space-evenly !important;
+  }
+
   .has-background-white-print {
     background-color: white !important;
   }

--- a/src/components/generics/pretty-links/PrettyBookLink.vue
+++ b/src/components/generics/pretty-links/PrettyBookLink.vue
@@ -1,8 +1,6 @@
 <template>
   <document-link :document="book" class="pretty-book-link has-hover-background">
-    <icon-book class="has-text-normal" />
-    <document-title :document="book" />,
-    <em class="has-text-normal">{{ book.author }}</em>
+    <pretty-book :book="book" />
   </document-link>
 </template>
 

--- a/src/components/generics/pretty-links/PrettyOutingLink.vue
+++ b/src/components/generics/pretty-links/PrettyOutingLink.vue
@@ -1,21 +1,6 @@
 <template>
   <document-link :document="outing" class="pretty-outing-link has-hover-background">
-    <span class="has-text-normal">
-      {{ outing.date_end }}
-      &hairsp;&bull;&hairsp;
-    </span>
-    <document-title :document="outing" />
-    <span class="has-text-normal">
-      <activities :activities="outing.activities" class="is-size-4 has-text-secondary icon-activities" />
-      &hairsp;&bull;&hairsp;
-      {{ outing.author.name }}
-      &hairsp;&bull;&hairsp;
-      <marker-condition :condition="outing.condition_rating" />
-      <marker-quality :quality="outing.quality" />
-      <marker-image-count v-if="outing.img_count != 0" :image-count="outing.img_count" />
-      <marker-gps-trace v-if="outing.geometry.has_geom_detail" />
-      <marker-soft-mobility v-if="outing.public_transport" />
-    </span>
+    <pretty-outing :outing="outing" />
   </document-link>
 </template>
 

--- a/src/components/generics/pretty-links/PrettyRouteLink.vue
+++ b/src/components/generics/pretty-links/PrettyRouteLink.vue
@@ -1,31 +1,12 @@
 <template>
   <document-link :document="route" class="pretty-route-link has-hover-background">
-    <document-title :document="route" />
-    <activities
-      v-if="!hideActivities"
-      :activities="route.activities"
-      class="is-size-4 has-text-secondary icon-activities"
+    <pretty-route
+      :route="route"
+      :hide-activities="hideActivities"
+      :hide-area="hideArea"
+      :hide-orientation="hideOrientation"
+      :hide-height-difficulties="hideHeightDiffDifficulties"
     />
-    <span
-      v-if="route.height_diff_difficulties && !hideHeightDiffDifficulties"
-      :title="$gettext('height_diff_difficulties')"
-      class="has-text-normal"
-    >
-      {{ route.height_diff_difficulties }}&nbsp;m,
-    </span>
-    <span v-if="route.orientations && !hideOrientation" :title="$gettext('orientations')" class="has-text-normal">
-      {{ route.orientations.join(', ') }},
-    </span>
-    <document-rating :document="route" class="has-text-normal" />
-    <marker-gps-trace v-if="route.geometry.has_geom_detail" class="has-text-normal" />
-    <span v-if="!hideArea" class="has-text-normal">
-      <em v-for="area in rangeAreas" :key="area.document_id">
-        &hairsp;&bull;&hairsp;
-        <small>
-          <document-title :document="area" />
-        </small>
-      </em>
-    </span>
   </document-link>
 </template>
 
@@ -65,10 +46,6 @@ export default {
 <style scoped lang="scss">
 .pretty-route-link {
   display: block;
-}
-
-.icon-activities {
-  line-height: 1;
 }
 
 @media print {

--- a/src/components/generics/pretty-links/PrettyWaypointLink.vue
+++ b/src/components/generics/pretty-links/PrettyWaypointLink.vue
@@ -1,11 +1,6 @@
 <template>
   <document-link :document="waypoint" class="pretty-waypoint-link has-hover-background">
-    <span :title="$gettext(waypoint.waypoint_type, 'waypoint_types')">
-      <icon-waypoint-type :waypoint-type="waypoint.waypoint_type" class="has-text-normal" />
-    </span>
-    <span>&#8239;</span>
-    <!-- thin space -->
-    <document-title :document="waypoint" /><span class="has-text-normal">, {{ waypoint.elevation }}&nbsp;m</span>
+    <pretty-waypoint :waypoint="waypoint" />
   </document-link>
 </template>
 

--- a/src/components/generics/pretty/PrettyBook.vue
+++ b/src/components/generics/pretty/PrettyBook.vue
@@ -1,0 +1,18 @@
+<template>
+  <span>
+    <icon-book class="has-text-normal" />
+    <document-title :document="book" />,
+    <em class="has-text-normal">{{ book.author }}</em>
+  </span>
+</template>
+
+<script>
+export default {
+  props: {
+    book: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>

--- a/src/components/generics/pretty/PrettyOuting.vue
+++ b/src/components/generics/pretty/PrettyOuting.vue
@@ -1,0 +1,31 @@
+<template>
+  <span>
+    <span class="has-text-normal">
+      {{ outing.date_end }}
+      &hairsp;&bull;&hairsp;
+    </span>
+    <document-title :document="outing" />
+    <span class="has-text-normal">
+      <activities :activities="outing.activities" class="is-size-4 has-text-secondary icon-activities" />
+      &hairsp;&bull;&hairsp;
+      {{ outing.author.name }}
+      &hairsp;&bull;&hairsp;
+      <marker-condition :condition="outing.condition_rating" />
+      <marker-quality :quality="outing.quality" />
+      <marker-image-count v-if="outing.img_count != 0" :image-count="outing.img_count" />
+      <marker-gps-trace v-if="outing.geometry.has_geom_detail" />
+      <marker-soft-mobility v-if="outing.public_transport" />
+    </span>
+  </span>
+</template>
+
+<script>
+export default {
+  props: {
+    outing: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>

--- a/src/components/generics/pretty/PrettyRoute.vue
+++ b/src/components/generics/pretty/PrettyRoute.vue
@@ -1,0 +1,75 @@
+<template>
+  <span class="has-hover-background">
+    <document-title :document="route" />
+    <activities
+      v-if="!hideActivities"
+      :activities="route.activities"
+      class="is-size-4 has-text-secondary icon-activities"
+    />
+    <span
+      v-if="route.height_diff_difficulties && !hideHeightDiffDifficulties"
+      :title="$gettext('height_diff_difficulties')"
+      class="has-text-normal"
+    >
+      {{ route.height_diff_difficulties }}&nbsp;m,
+    </span>
+    <span v-if="route.orientations && !hideOrientation" :title="$gettext('orientations')" class="has-text-normal">
+      {{ route.orientations.join(', ') }},
+    </span>
+    <document-rating :document="route" class="has-text-normal" />
+    <marker-gps-trace v-if="route.geometry.has_geom_detail" class="has-text-normal" />
+    <span v-if="!hideArea" class="has-text-normal">
+      <em v-for="area in rangeAreas" :key="area.document_id">
+        &hairsp;&bull;&hairsp;
+        <small>
+          <document-title :document="area" />
+        </small>
+      </em>
+    </span>
+  </span>
+</template>
+
+<script>
+export default {
+  props: {
+    route: {
+      type: Object,
+      required: true,
+    },
+    hideActivities: {
+      type: Boolean,
+      default: false,
+    },
+    hideArea: {
+      type: Boolean,
+      default: false,
+    },
+    hideOrientation: {
+      type: Boolean,
+      default: false,
+    },
+    hideHeightDiffDifficulties: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  computed: {
+    rangeAreas() {
+      return this.route.areas.filter((area) => area.area_type === 'range');
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.icon-activities {
+  line-height: 1;
+}
+
+@media print {
+  .is-size-4 {
+    font-size: 1rem !important;
+  }
+}
+</style>

--- a/src/components/generics/pretty/PrettyWaypoint.vue
+++ b/src/components/generics/pretty/PrettyWaypoint.vue
@@ -1,0 +1,21 @@
+<template>
+  <span>
+    <span :title="$gettext(waypoint.waypoint_type, 'waypoint_types')">
+      <icon-waypoint-type :waypoint-type="waypoint.waypoint_type" class="has-text-normal" />
+    </span>
+    <span>&#8239;</span>
+    <!-- thin space -->
+    <document-title :document="waypoint" /><span class="has-text-normal">, {{ waypoint.elevation }}&nbsp;m</span>
+  </span>
+</template>
+
+<script>
+export default {
+  props: {
+    waypoint: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>

--- a/src/components/map/OlMap.vue
+++ b/src/components/map/OlMap.vue
@@ -874,7 +874,7 @@ export default {
       const query = Object.assign({}, this.$route.query);
 
       query.bbox = this.filterDocumentsWithMap ? bounds.map(Math.round).join(',') : undefined;
-      if (query.bbox !== this.$route.query.bbox) {
+      if (query.bbox !== this.$route.query.bbox && !this.$route.name.endsWith('-print')) {
         this.$router.push({ query });
       }
     },

--- a/src/js/view-mode-mixin.js
+++ b/src/js/view-mode-mixin.js
@@ -9,8 +9,13 @@ export default {
       return this.$route.name.endsWith('-edit') || this.$route.name.endsWith('-add');
     },
 
+    isPrintingView() {
+      // means in a list of document to print
+      return this.$route.name.endsWith('-print');
+    },
+
     isNormalView() {
-      return !this.isDraftView && !this.isVersionView;
+      return !this.isDraftView && !this.isVersionView && !this.isPrintingView;
     },
   },
 };

--- a/src/js/vue-plugins/font-awesome-config.js
+++ b/src/js/vue-plugins/font-awesome-config.js
@@ -11,6 +11,7 @@ import { faTrashAlt as faTrashAltRegular } from '@fortawesome/free-regular-svg-i
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons/faAngleDown';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons/faArrowRight';
+import { faArrowUp } from '@fortawesome/free-solid-svg-icons/faArrowUp';
 import { faArrowsAltV } from '@fortawesome/free-solid-svg-icons/faArrowsAltV';
 import { faAt } from '@fortawesome/free-solid-svg-icons/faAt';
 import { faAtlas } from '@fortawesome/free-solid-svg-icons/faAtlas';
@@ -80,6 +81,7 @@ import { faObjectGroup } from '@fortawesome/free-solid-svg-icons/faObjectGroup';
 import { faPen } from '@fortawesome/free-solid-svg-icons/faPen';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faPlusCircle } from '@fortawesome/free-solid-svg-icons/faPlusCircle';
+import { faPrint } from '@fortawesome/free-solid-svg-icons/faPrint';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
 import { faRedoAlt } from '@fortawesome/free-solid-svg-icons/faRedoAlt';
 import { faRobot } from '@fortawesome/free-solid-svg-icons/faRobot';
@@ -231,6 +233,7 @@ export default function install(Vue) {
     faArrowsAltV,
     faArrowLeft,
     faArrowRight,
+    faArrowUp,
     faAt,
     faAtlas,
     faBan,
@@ -299,6 +302,7 @@ export default function install(Vue) {
     faPen,
     faPlus,
     faPlusCircle,
+    faPrint,
     faQuestionCircle,
     faRedoAlt,
     faRobot,

--- a/src/js/vue-plugins/router.js
+++ b/src/js/vue-plugins/router.js
@@ -14,6 +14,7 @@ import ProfileView from '@/views/document/ProfileView';
 import RouteView from '@/views/document/RouteView';
 import WaypointView from '@/views/document/WaypointView';
 import XreportView from '@/views/document/XreportView';
+import DocumentsPrintingView from '@/views/documents/DocumentsPrintingView';
 import DashboardView from '@/views/portals/DashboardView';
 import FeedView from '@/views/portals/FeedView';
 import SophiePictureContestView from '@/views/portals/SophiePictureContestView';
@@ -81,6 +82,12 @@ const addDocumentTypeView = function (def, viewComponent, editionComponent) {
     path: '/' + def.documentType + 's',
     name: def.documentType + 's',
     component: DocumentsView,
+  });
+
+  routes.push({
+    path: '/print/' + def.documentType + 's',
+    name: def.documentType + 's-print',
+    component: DocumentsPrintingView,
   });
 
   routes.push({

--- a/src/js/vue-plugins/router.js
+++ b/src/js/vue-plugins/router.js
@@ -85,7 +85,7 @@ const addDocumentTypeView = function (def, viewComponent, editionComponent) {
   });
 
   routes.push({
-    path: '/print/' + def.documentType + 's',
+    path: '/' + def.documentType + 's/print',
     name: def.documentType + 's-print',
     component: DocumentsPrintingView,
   });

--- a/src/views/document/utils/DocumentViewHeader.vue
+++ b/src/views/document/utils/DocumentViewHeader.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="view-container">
     <div v-if="!document.not_authorized">
-      <html-header v-if="!isDraftView" :title="title" />
+      <html-header v-if="!isDraftView && !isPrintingView" :title="title" />
 
       <document-version-banner :version="version" :document="document" />
 
       <div class="box">
-        <span v-if="!isDraftView" class="is-pulled-right button-bar no-print">
+        <span v-if="!isDraftView && !isPrintingView" class="is-pulled-right button-bar no-print">
           <follow-button :document="document" />
           <tags-button :document="document" />
 

--- a/src/views/document/utils/DocumentViewHeader.vue
+++ b/src/views/document/utils/DocumentViewHeader.vue
@@ -6,9 +6,10 @@
       <document-version-banner :version="version" :document="document" />
 
       <div class="box">
-        <span v-if="!isDraftView && !isPrintingView" class="is-pulled-right button-bar no-print">
-          <follow-button :document="document" />
-          <tags-button :document="document" />
+        <span v-if="!isDraftView" class="is-pulled-right button-bar no-print">
+          <gotop-button v-if="isPrintingView"/>
+          <follow-button v-if="!isPrintingView" :document="document" />
+          <tags-button v-if="!isPrintingView" :document="document" />
 
           <social-network-sharing v-if="documentType != 'profile' && isNormalView" />
 
@@ -54,6 +55,7 @@
 <script>
 import DocumentVersionBanner from './DocumentVersionBanner';
 import FollowButton from './FollowButton';
+import GotopButton from './GotopButton';
 import SocialNetworkSharing from './SocialNetworkSharing';
 import TagsButton from './TagsButton';
 
@@ -65,6 +67,7 @@ export default {
   components: {
     ImagesUploader,
     FollowButton,
+    GotopButton,
     TagsButton,
     SocialNetworkSharing,
     DocumentVersionBanner,

--- a/src/views/document/utils/GotopButton.vue
+++ b/src/views/document/utils/GotopButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <span class="gotop-button" @click="onClick" title="Go back to the top of the page">
+    <fa-icon icon="arrow-up" />
+  </span>
+</template>
+
+<script>
+export default {
+
+  methods: {
+    onClick() {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.gotop-button {
+  cursor: pointer;
+}
+</style>

--- a/src/views/document/utils/boxes/ImagesBox.vue
+++ b/src/views/document/utils/boxes/ImagesBox.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="document.associations.images && document.associations.images.length !== 0" class="box no-print">
+  <div v-if="document.associations.images && document.associations.images.length !== 0" class="box no-print image-box">
     <gallery :images="document.associations.images" ref="gallery" />
   </div>
 </template>

--- a/src/views/document/utils/document-view-mixin.js
+++ b/src/views/document/utils/document-view-mixin.js
@@ -95,11 +95,15 @@ export default {
      * properties that are deducted from URL
      */
     documentId() {
-      if (this.isDraftView || this.isPrintingView) return this.draft.document_id;
+      if (this.isDraftView || this.isPrintingView) {
+        return this.draft.document_id;
+      }
       return parseInt(this.$route.params.id, 10);
     },
     documentType() {
-      if (this.isPrintingView) return this.$route.name.split('s-')[0];
+      if (this.isPrintingView) {
+        return this.$route.name.split('s-')[0];
+      }
       return this.$route.name.split('-')[0];
     },
     fields() {

--- a/src/views/document/utils/document-view-mixin.js
+++ b/src/views/document/utils/document-view-mixin.js
@@ -95,9 +95,11 @@ export default {
      * properties that are deducted from URL
      */
     documentId() {
+      if (this.isDraftView || this.isPrintingView) return this.draft.document_id;
       return parseInt(this.$route.params.id, 10);
     },
     documentType() {
+      if (this.isPrintingView) return this.$route.name.split('s-')[0];
       return this.$route.name.split('-')[0];
     },
     fields() {
@@ -174,7 +176,7 @@ export default {
             };
             this.$emit('updateHead');
           });
-      } else if (this.isDraftView) {
+      } else if (this.isDraftView || this.isPrintingView) {
         this.promise = {};
 
         this.$imageViewer.clear();

--- a/src/views/documents/DocumentsPrintingView.vue
+++ b/src/views/documents/DocumentsPrintingView.vue
@@ -1,13 +1,22 @@
 <template>
   <div class="section documents-view">
     <html-header :title="getDocumentTypeTitle(documentType)" />
+    <printing-options
+      :documents="documents"
+      :promises="promises"
+      @set-page-breaks="pageBreaks = $event"
+      @set-image-printing="includeImages = $event"
+      @set-summary-visibility="summaryVisibility = $event"
+    />
     <printing-summary
+      v-if="summaryVisibility"
       :documents="documents"
       :document-type="documentType"
       @summary-click="scrollTo($event)"
     />
     <div :class="['documents-container', includeImages ? 'print-image' : '']">
       <div v-for="(doc, index) in promises" :key="index" class="column">
+        <div v-if="pageBreaks && (index > 0 || summaryVisibility)" class="page-break" />
         <loading-notification :promise="doc.promise" />
         <component
           v-if="doc.promise.data"
@@ -21,6 +30,7 @@
 </template>
 
 <script>
+import PrintingOptions from './utils/PrintingOptions';
 import PrintingSummary from './utils/PrintingSummary';
 
 import c2c from '@/js/apis/c2c';
@@ -36,7 +46,6 @@ import RouteView from '@/views/document/RouteView';
 import WaypointView from '@/views/document/WaypointView';
 import XreportView from '@/views/document/XreportView';
 
-
 export default {
   name: 'DocumentsPrintingView',
 
@@ -47,6 +56,7 @@ export default {
     ImageView,
     MapView,
     OutingView,
+    PrintingOptions,
     PrintingSummary,
     ProfileView,
     RouteView,
@@ -58,6 +68,9 @@ export default {
     return {
       promise: null,
       promises: [],
+      pageBreaks: false,
+      includeImages: false,
+      summaryVisibility: true,
     };
   },
 
@@ -114,3 +127,9 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.page-break {
+  page-break-after: always;
+}
+</style>

--- a/src/views/documents/DocumentsPrintingView.vue
+++ b/src/views/documents/DocumentsPrintingView.vue
@@ -4,6 +4,7 @@
     <printing-summary
       :documents="documents"
       :document-type="documentType"
+      @summary-click="scrollTo($event)"
     />
     <div :class="['documents-container', includeImages ? 'print-image' : '']">
       <div v-for="(doc, index) in promises" :key="index" class="column">
@@ -97,6 +98,17 @@ export default {
 
     getDocumentTypeTitle(documentType) {
       return this.$gettext(documentType + 's');
+    },
+
+    scrollTo(name) {
+      const el = document.querySelector("#toc-entry-"+name);
+      if (el) {
+        const docEl = document.documentElement;
+        const docRect = docEl.getBoundingClientRect();
+        const elRect = el.getBoundingClientRect();
+        const y = elRect.top - docRect.top;
+        window.scrollTo(0, y - 50); // navbar height ...
+      }
     },
 
   },

--- a/src/views/documents/DocumentsPrintingView.vue
+++ b/src/views/documents/DocumentsPrintingView.vue
@@ -93,18 +93,16 @@ export default {
   methods: {
     load() {
       this.promise = c2c[this.documentType].getAll(this.$route.query).then(() => {
-        this.promises = this.promise.data.documents.map((doc) => {
-          return {
-            promise: c2c[this.documentType].getCooked(
-              doc.document_id,
-              this.$route.params.lang ?? this.$language.current
-            ),
-            documentId: doc.document_id,
-            expectedLang: this.$route.params.lang ?? this.$language.current,
-            documentType: this.documentType,
-            version: null,
-            fields: constants.objectDefinitions[this.documentType].fields,
-          };
+        this.promises = this.promise.data.documents.map((doc) => ({
+          promise: c2c[this.documentType].getCooked(
+            doc.document_id,
+            this.$route.params.lang ?? this.$language.current
+          ),
+          documentId: doc.document_id,
+          expectedLang: this.$route.params.lang ?? this.$language.current,
+          documentType: this.documentType,
+          version: null,
+          fields: constants.objectDefinitions[this.documentType].fields,
         });
       });
     },

--- a/src/views/documents/DocumentsPrintingView.vue
+++ b/src/views/documents/DocumentsPrintingView.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="section documents-view">
-    <html-header :title="getDocumentTypeTitle(documentType)" />
+    <html-header :title="'Printing - ' + getDocumentTypeTitle(documentType)" />
+    <h1 class="title is-1 box">Print a selection of documents</h1>
     <printing-options
       :documents="documents"
       :promises="promises"
@@ -103,7 +104,7 @@ export default {
           documentType: this.documentType,
           version: null,
           fields: constants.objectDefinitions[this.documentType].fields,
-        });
+        }));
       });
     },
 

--- a/src/views/documents/DocumentsPrintingView.vue
+++ b/src/views/documents/DocumentsPrintingView.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="section documents-view">
     <html-header :title="getDocumentTypeTitle(documentType)" />
+    <printing-summary
+      :documents="documents"
+      :document-type="documentType"
+    />
     <div :class="['documents-container', includeImages ? 'print-image' : '']">
       <div v-for="(doc, index) in promises" :key="index" class="column">
         <loading-notification :promise="doc.promise" />
@@ -16,6 +20,8 @@
 </template>
 
 <script>
+import PrintingSummary from './utils/PrintingSummary';
+
 import c2c from '@/js/apis/c2c';
 import constants from '@/js/constants';
 import AreaView from '@/views/document/AreaView';
@@ -29,6 +35,7 @@ import RouteView from '@/views/document/RouteView';
 import WaypointView from '@/views/document/WaypointView';
 import XreportView from '@/views/document/XreportView';
 
+
 export default {
   name: 'DocumentsPrintingView',
 
@@ -39,6 +46,7 @@ export default {
     ImageView,
     MapView,
     OutingView,
+    PrintingSummary,
     ProfileView,
     RouteView,
     WaypointView,

--- a/src/views/documents/DocumentsPrintingView.vue
+++ b/src/views/documents/DocumentsPrintingView.vue
@@ -118,7 +118,7 @@ export default {
         const docRect = docEl.getBoundingClientRect();
         const elRect = el.getBoundingClientRect();
         const y = elRect.top - docRect.top;
-        window.scrollTo(0, y - 50); // navbar height ...
+        window.scrollTo({ top: y - 50, behavior: 'smooth' }); // navbar height ...
       }
     },
 

--- a/src/views/documents/DocumentsPrintingView.vue
+++ b/src/views/documents/DocumentsPrintingView.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="section documents-view">
+    <html-header :title="getDocumentTypeTitle(documentType)" />
+    <div :class="['documents-container', includeImages ? 'print-image' : '']">
+      <div v-for="(doc, index) in promises" :key="index" class="column">
+        <loading-notification :promise="doc.promise" />
+        <component
+          v-if="doc.promise.data"
+          :is="documentType + '-view'"
+          :draft="doc.promise.data"
+          :id="'toc-entry-' + index"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import c2c from '@/js/apis/c2c';
+import constants from '@/js/constants';
+import AreaView from '@/views/document/AreaView';
+import ArticleView from '@/views/document/ArticleView';
+import BookView from '@/views/document/BookView';
+import ImageView from '@/views/document/ImageView';
+import MapView from '@/views/document/MapView';
+import OutingView from '@/views/document/OutingView';
+import ProfileView from '@/views/document/ProfileView';
+import RouteView from '@/views/document/RouteView';
+import WaypointView from '@/views/document/WaypointView';
+import XreportView from '@/views/document/XreportView';
+
+export default {
+  name: 'DocumentsPrintingView',
+
+  components: {
+    AreaView,
+    ArticleView,
+    BookView,
+    ImageView,
+    MapView,
+    OutingView,
+    ProfileView,
+    RouteView,
+    WaypointView,
+    XreportView,
+  },
+
+  data() {
+    return {
+      promise: null,
+      promises: [],
+    };
+  },
+
+  computed: {
+    documentType() {
+      return this.$route.name.slice(0, -'s-print'.length);
+    },
+    documents() {
+      return this.promise.data;
+    },
+  },
+
+  watch: {
+    $route: {
+      handler: 'load',
+      immediate: true,
+    },
+  },
+
+  methods: {
+    load() {
+      this.promise = c2c[this.documentType].getAll(this.$route.query).then(() => {
+        this.promises = this.promise.data.documents.map((doc) => {
+          return {
+            promise: c2c[this.documentType].getCooked(
+              doc.document_id,
+              this.$route.params.lang ?? this.$language.current
+            ),
+            documentId: doc.document_id,
+            expectedLang: this.$route.params.lang ?? this.$language.current,
+            documentType: this.documentType,
+            version: null,
+            fields: constants.objectDefinitions[this.documentType].fields,
+          };
+        });
+      });
+    },
+
+    getDocumentTypeTitle(documentType) {
+      return this.$gettext(documentType + 's');
+    },
+
+  },
+};
+</script>

--- a/src/views/documents/utils/PrintButton.vue
+++ b/src/views/documents/utils/PrintButton.vue
@@ -1,0 +1,15 @@
+<template>
+  <a target="_blank" :href="path">
+    <button class="button is-primary is-size-7-mobile">Print search results</button>
+  </a>
+</template>
+
+<script>
+export default {
+  computed: {
+    path() {
+      return '/print' + this.$route.fullPath;
+    },
+  },
+};
+</script>

--- a/src/views/documents/utils/PrintButton.vue
+++ b/src/views/documents/utils/PrintButton.vue
@@ -1,14 +1,24 @@
 <template>
-  <a target="_blank" :href="path">
-    <button class="button is-primary is-size-7-mobile">Print search results</button>
-  </a>
+  <router-link target="_blank" :to="path">
+    <button class="button is-primary is-size-7-mobile">
+      <fa-icon icon="print"></fa-icon>
+      <span class="is-hidden-touch">&nbsp;</span>
+      <span class="is-hidden-touch" v-translate>Print search results</span>
+    </button>
+  </router-link>
 </template>
 
 <script>
+import urlMixin from './url-mixin';
+
 export default {
+  mixins: [urlMixin],
+
   computed: {
     path() {
-      return '/print' + this.$route.fullPath;
+       return {path: this.documentType+'s/print',
+       query: this.$route.query,
+      }
     },
   },
 };

--- a/src/views/documents/utils/PrintingOptions.vue
+++ b/src/views/documents/utils/PrintingOptions.vue
@@ -8,9 +8,9 @@
       <div class="column printing-option-section">
         <h2 class="title is-2">Other options</h2>
         <ul>
-          <li><input class="print-option-checkbox" v-model="pageBreaks" type="checkbox" />Add page breaks before each document</li>
-          <li><input class="print-option-checkbox" v-model="imagePrinting" type="checkbox" />Include image section</li>
-          <li><input class="print-option-checkbox" v-model="summaryVisibility" checked type="checkbox" />Include a summary</li>
+          <li><label><input class="print-option-checkbox" v-model="pageBreaks" type="checkbox" />Add page breaks before each document</label></li>
+          <li><label><input class="print-option-checkbox" v-model="imagePrinting" type="checkbox" />Include image section</label></li>
+          <li><label><input class="print-option-checkbox" v-model="summaryVisibility" checked type="checkbox" />Include a summary</label></li>
         </ul>
       </div>
       <div class="column printing-option-section">

--- a/src/views/documents/utils/PrintingOptions.vue
+++ b/src/views/documents/utils/PrintingOptions.vue
@@ -1,0 +1,117 @@
+<template>
+  <div class="box no-print">
+    <h1 class="title is-1">Printing a selection of documents</h1>
+    <div class="printing-option-section">
+      <h2 class="title is-2">Number of documents</h2>
+      <page-selector :documents="documents" page-type="print" />.
+    </div>
+    <div class="printing-option-section">
+      <h2 class="title is-2">Other options</h2>
+      <ul>
+        <li><input class="print-option-checkbox" v-model="pageBreaks" type="checkbox" />Add page breaks before each document.</li>
+        <li><input class="print-option-checkbox" v-model="imagePrinting" type="checkbox" />Include images.</li>
+        <li><input class="print-option-checkbox" v-model="summaryVisibility" checked type="checkbox" />Include a summary.</li>
+      </ul>
+    </div>
+    <div class="printing-option-section">
+      <h2 class="title is-2">Printing</h2>
+      <button :disabled="allLoaded" class="button is-primary print-button" onclick="window.print()">Print</button>
+      <span v-if="allLoaded">Loaded {{ totalResolved }} documents out of {{ total }}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import PageSelector from './PageSelector';
+
+export default {
+  components: {
+    PageSelector,
+  },
+
+  props: {
+    documents: {
+      type: Object,
+      default: null,
+    },
+    promises: {
+      type: Array,
+      default: null,
+    },
+  },
+
+  data() {
+    return {
+      totalResolved: 0,
+      pageBreaks: false,
+      imagePrinting: false,
+      summaryVisibility: true,
+    };
+  },
+
+  computed: {
+    offset() {
+      return parseInt(this.$route.query.offset ?? 0);
+    },
+    total() {
+      return this.promises.length;
+    },
+    allLoaded() {
+      return this.totalResolved < this.total;
+    },
+  },
+
+  watch: {
+    promises: 'trackResolve',
+    pageBreaks: 'setPageBreaks',
+    imagePrinting: 'setImagePrinting',
+    summaryVisibility: 'setSummaryVisibility',
+  },
+
+  methods: {
+    setPageBreaks() {
+      this.$emit('set-page-breaks', this.pageBreaks);
+    },
+    setImagePrinting() {
+      this.$emit('set-image-printing', this.imagePrinting);
+    },
+    setSummaryVisibility() {
+      this.$emit('set-summary-visibility', this.summaryVisibility);
+    },
+    trackResolve() {
+      this.totalResolved = 0;
+      this.promises.map((p) => {
+        p.promise.then(() => {
+          this.totalResolved++;
+        });
+      });
+    },
+
+  },
+};
+</script>
+
+<style scoped>
+.printing-option-section {
+  margin-bottom: 1.5rem;
+}
+.printing-option-section h1 {
+    font-size: 1.8rem;
+    margin-bottom: 0.5em;
+    border-bottom: 1px solid #ddd;
+}
+.printing-option-section h2 {
+    font-size: 1.8rem;
+    margin-bottom: 0.5em;
+    border-bottom: 1px solid #ddd;
+}
+
+.print-button {
+    vertical-align: baseline;
+    margin-right: 10px;
+}
+
+.print-option-checkbox {
+    margin-right: 5px;
+}
+</style>

--- a/src/views/documents/utils/PrintingOptions.vue
+++ b/src/views/documents/utils/PrintingOptions.vue
@@ -1,22 +1,23 @@
 <template>
   <div class="box no-print">
-    <h1 class="title is-1">Print a selection of documents</h1>
-    <div class="printing-option-section">
-      <h2 class="title is-2">Number of documents</h2>
-      <page-selector :documents="documents" page-type="print" />.
-    </div>
-    <div class="printing-option-section">
-      <h2 class="title is-2">Other options</h2>
-      <ul>
-        <li><input class="print-option-checkbox" v-model="pageBreaks" type="checkbox" />Add page breaks before each document.</li>
-        <li><input class="print-option-checkbox" v-model="imagePrinting" type="checkbox" />Include images.</li>
-        <li><input class="print-option-checkbox" v-model="summaryVisibility" checked type="checkbox" />Include a summary.</li>
-      </ul>
-    </div>
-    <div class="printing-option-section">
-      <h2 class="title is-2">Printing</h2>
-      <button :disabled="allLoaded" class="button is-primary print-button" onclick="window.print()">Print</button>
-      <span v-if="allLoaded">Loaded {{ totalResolved }} documents out of {{ total }}</span>
+    <div class="columns">
+      <div class="column printing-option-section">
+        <h2 class="title is-2">Number of documents</h2>
+        <page-selector :documents="documents" page-type="print" />.
+      </div>
+      <div class="column printing-option-section">
+        <h2 class="title is-2">Other options</h2>
+        <ul>
+          <li><input class="print-option-checkbox" v-model="pageBreaks" type="checkbox" />Add page breaks before each document</li>
+          <li><input class="print-option-checkbox" v-model="imagePrinting" type="checkbox" />Include image section</li>
+          <li><input class="print-option-checkbox" v-model="summaryVisibility" checked type="checkbox" />Include a summary</li>
+        </ul>
+      </div>
+      <div class="column printing-option-section">
+        <h2 class="title is-2">Printing</h2>
+        <button :disabled="isLoading" class="button is-primary print-button" onclick="window.print()">Print</button>
+        <span v-if="isLoading">Loaded {{ totalResolved }} documents out of {{ total }}</span>
+      </div>
     </div>
   </div>
 </template>
@@ -56,7 +57,7 @@ export default {
     total() {
       return this.promises.length;
     },
-    allLoaded() {
+    isLoading() {
       return this.totalResolved < this.total;
     },
   },

--- a/src/views/documents/utils/PrintingOptions.vue
+++ b/src/views/documents/utils/PrintingOptions.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="box no-print">
-    <h1 class="title is-1">Printing a selection of documents</h1>
+    <h1 class="title is-1">Print a selection of documents</h1>
     <div class="printing-option-section">
       <h2 class="title is-2">Number of documents</h2>
       <page-selector :documents="documents" page-type="print" />.

--- a/src/views/documents/utils/PrintingSummary.vue
+++ b/src/views/documents/utils/PrintingSummary.vue
@@ -2,12 +2,14 @@
   <div v-if="documents" class="box">
     <h1 class="title is-1">Summary</h1>
     <div v-for="(document, index) in documents.documents" :key="index">
-      <span class="toc-number">{{ index + 1 }}. </span>
-      <pretty-route :route="document" v-if="documentType == 'route'" />
-      <pretty-waypoint :waypoint="document" v-else-if="documentType == 'waypoint'" />
-      <pretty-book :book="document" v-else-if="documentType == 'book'" />
-      <pretty-outing :outing="document" v-else-if="documentType == 'outing'" />
-      <document-title :document="document" v-else />
+      <span @click="sendSummaryClick(index)">
+        <span class="toc-number">{{ index + 1 }}. </span>
+        <pretty-route :route="document" v-if="documentType == 'route'" />
+        <pretty-waypoint :waypoint="document" v-else-if="documentType == 'waypoint'" />
+        <pretty-book :book="document" v-else-if="documentType == 'book'" />
+        <pretty-outing :outing="document" v-else-if="documentType == 'outing'" />
+        <document-title :document="document" v-else />
+      </span>
     </div>
   </div>
 </template>
@@ -27,6 +29,14 @@ export default {
       type: String,
       default: 'route',
     },
+  },
+
+  methods: {
+
+    sendSummaryClick(index) {
+      this.$emit("summary-click", index);
+    }
+
   },
 };
 </script>

--- a/src/views/documents/utils/PrintingSummary.vue
+++ b/src/views/documents/utils/PrintingSummary.vue
@@ -2,7 +2,7 @@
   <div v-if="documents" class="box">
     <h1 class="title is-1">Summary</h1>
     <div v-for="(document, index) in documents.documents" :key="index">
-      <span @click="sendSummaryClick(index)">
+      <span class="toc-entry" @click="sendSummaryClick(index)">
         <span class="toc-number">{{ index + 1 }}. </span>
         <pretty-route :route="document" v-if="documentType == 'route'" />
         <pretty-waypoint :waypoint="document" v-else-if="documentType == 'waypoint'" />
@@ -32,11 +32,9 @@ export default {
   },
 
   methods: {
-
     sendSummaryClick(index) {
       this.$emit("summary-click", index);
     }
-
   },
 };
 </script>
@@ -44,5 +42,8 @@ export default {
 <style scoped>
 .toc-number {
   margin-right: 7px;
+}
+.toc-entry {
+  cursor: pointer;
 }
 </style>

--- a/src/views/documents/utils/PrintingSummary.vue
+++ b/src/views/documents/utils/PrintingSummary.vue
@@ -1,0 +1,38 @@
+<template>
+  <div v-if="documents" class="box">
+    <h1 class="title is-1">Summary</h1>
+    <div v-for="(document, index) in documents.documents" :key="index">
+      <span class="toc-number">{{ index + 1 }}. </span>
+      <pretty-route :route="document" v-if="documentType == 'route'" />
+      <pretty-waypoint :waypoint="document" v-else-if="documentType == 'waypoint'" />
+      <pretty-book :book="document" v-else-if="documentType == 'book'" />
+      <pretty-outing :outing="document" v-else-if="documentType == 'outing'" />
+      <document-title :document="document" v-else />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    documents: {
+      type: Object,
+      default: null,
+    },
+    promises: {
+      type: Array,
+      default: null,
+    },
+    documentType: {
+      type: String,
+      default: 'route',
+    },
+  },
+};
+</script>
+
+<style scoped>
+.toc-number {
+  margin-right: 7px;
+}
+</style>

--- a/src/views/documents/utils/QueryItems.vue
+++ b/src/views/documents/utils/QueryItems.vue
@@ -67,7 +67,7 @@
         @add="addTag"
       />
       <load-user-preferences-button class="is-hidden-tablet query-item-component" />
-      <export-csv-button v-if="listMode" class="is-small-mobile"></export-csv-button>
+      <export-csv-button v-if="listMode" class="is-small-mobile query-item-component"></export-csv-button>
       <print-button />
     </div>
     <div class="query-items-tags is-hidden-mobile">

--- a/src/views/documents/utils/QueryItems.vue
+++ b/src/views/documents/utils/QueryItems.vue
@@ -68,6 +68,7 @@
       />
       <load-user-preferences-button class="is-hidden-tablet query-item-component" />
       <export-csv-button v-if="listMode" class="is-small-mobile"></export-csv-button>
+      <print-button />
     </div>
     <div class="query-items-tags is-hidden-mobile">
       <query-tags :documents="tags" @remove="removeTag"></query-tags>
@@ -79,6 +80,7 @@
 import AssociationQueryItem from './AssociationQueryItem';
 import ExportCsvButton from './ExportCsvButton.vue';
 import LoadUserPreferencesButton from './LoadUserPreferencesButton';
+import PrintButton from './PrintButton';
 import QueryItem from './QueryItem';
 import QuerySortDropdown from './QuerySortDropdown';
 import QueryTags from './QueryTags';
@@ -219,6 +221,7 @@ export default {
 
   components: {
     AssociationQueryItem,
+    PrintButton,
     QueryItem,
     QuerySortDropdown,
     QueryTags,


### PR DESCRIPTION
Hello,

Here is a proposition to add an option to print a pdf containing the list of routes of a research.
For instance, one can find the list of routes located in an area with a suitable difficulty level, then click on the new `Print` button, which will generate a pdf to be saved on a phone or printed.

To do this, I needed a few changes on the organization for document views. Indeed, I needed to display, in a single view, multiple documents, so each document needed to be a component and not a view. I therefore separated the "document api loading" from the displaying of the document. Here is a list of the changes:
- Each AreaView, WaypointView, ... are now viewed as components. `document-view-mixin.js` reflects this. They now take a `promise`, `documentId`, `documentType`, `fields` and `expectedLang` as props instead of finding/loading it themselves
- There is a new view, `DocumentView`, in charge of choosing the right component (AreaView, WaypointView, ...) to load with the right props (`promise`, `documentId`, ...). The route mechanism for document is updated.
- There is a new view, `PrintDocumentList`, which loads all documents, and when everything is resolved, call `window.print()`. The routes for this new view is `/print/{article, waypoint, ...}`
- A button is added to go to the PrintDocumentList from a search, with the same filter.

I hope that this is the right solution to implement this feature! Let me know what you think, I can adapt it to the maintainer's taste. And thanks for this amazing open source project :)

(There are many other natural improvements, such as adding a table of content, but I leave them for another PR.)