### PR TITLE
Fix async bug on outing edition

### DIFF
--- a/src/js/get-fundraiser.js
+++ b/src/js/get-fundraiser.js
@@ -148,7 +148,6 @@ const mapping = {
     // Western Australia
     url: 'https://www.climberswa.asn.au/cawa/bolting-fund/',
   },
-  
 
   // Others
   14151: {

--- a/src/views/wiki/edition/OutingEditionView.vue
+++ b/src/views/wiki/edition/OutingEditionView.vue
@@ -300,8 +300,8 @@ export default {
       }
     },
 
-    fitMapToDocuments() {
-      this.bbox = this.$refs.mapInput.fitMapToDocuments();
+    async fitMapToDocuments() {
+      this.bbox = await this.$refs.mapInput.fitMapToDocuments();
     },
 
     updateRoutes(reason, fitMap) {


### PR DESCRIPTION
The bug : 


1. Go to the big green button "add a new outing" on the top navbar
2. select an activity
3. selection a route in the list

The map is centered on your route (ok), but the list is now missing. It you move the map to get other route in the same extent, it does not update.

I'm not familiar with `async`/`await` in JS, so another pair of eyes is welcome !

 