### PR TITLE
Allow to compute map size on fit when map is hidden

### DIFF
--- a/src/views/documents/DocumentsView.vue
+++ b/src/views/documents/DocumentsView.vue
@@ -347,7 +347,6 @@ $cards-gap: 0.25rem;
   .mobile-mode-both {
     .map-container {
       visibility: hidden; // map does not like to be in a display none...
-      height: 0;
     }
   }
 }


### PR DESCRIPTION
Fixes #2523 
The downside being that map tiles are downloaded even if the map is not displayed later on.
Maybe we could try to compute the size based one other DOM elements (e.g. the list), but that could break the isolation and all.

What do you think?