### PR TITLE
New design feed

### DIFF
--- a/src/components/cards/FeedCard.vue
+++ b/src/components/cards/FeedCard.vue
@@ -60,22 +60,12 @@
     </card-row>
 
     <card-row v-if="item.document.areas && item.document.areas.length">
-      <card-region-item :document="item.document" />
-    </card-row>
-
-    <card-row>
+      <card-region-item :document="item.document" class="is-ellipsed" />
       <span>
         <card-activities-item v-if="item.document.activities" :activities="item.document.activities" />
-      </span>
-      <span>
         <marker-soft-mobility v-if="documentType === 'outing' && item.document.public_transport" />
-        &nbsp;
         <marker-image-count :image-count="item.document.img_count" />
-        &nbsp;
         <marker-gps-trace v-if="item.document.geometry && item.document.geometry.has_geom_detail" />
-      </span>
-      <span> {{ $dateUtils.timeAgo(item.time) }} </span>
-      <span>
         <marker-condition v-if="documentType === 'outing'" :condition="item.document.condition_rating" />
         <marker-quality :quality="item.document.quality" />
       </span>
@@ -199,8 +189,8 @@ export default {
 
 .avatar {
   border-radius: 50%;
-  width: 36px;
-  height: 36px;
+  width: 24px;
+  height: 24px;
   vertical-align: bottom;
   margin-right: 0.5rem;
 }

--- a/src/components/cards/FeedCard.vue
+++ b/src/components/cards/FeedCard.vue
@@ -1,28 +1,10 @@
 <template>
   <card-container :document="document">
-    <card-title>
-      <span :title="$gettext('User avatar')">
-        <img
-          v-if="!useDefaultAvatarIcon"
-          class="avatar"
-          alt="Avatar"
-          @error="useDefaultAvatarIcon = true"
-          :src="$options.forumAvatarUrl + item.user.forum_username + '/36/1_1.png'"
-          loading="lazy"
-        />
-        <fa-icon v-else icon="user" class="is-size-3 has-text-grey" />
-      </span>
-      <span>
-        <document-title :document="item.user" />
-        <span class="has-text-weight-normal">&nbsp;{{ actionLine }}</span>
-      </span>
-
-      <marker-document-type :document-type="documentType" class="is-pulled-right is-size-3" />
-    </card-title>
-
     <card-row>
-      <document-title :document="item.document" class="has-text-weight-bold" />
-      <span v-if="documentType === 'outing'" class="is-nowrap has-left-margin-mobile">{{ dates }}</span>
+      <marker-document-type :document-type="documentType" class="is-pulled-left is-size-3" />
+      <document-title :document="item.document" class="has-text-weight-bold has-left-padding" />
+      <span v-if="documentType === 'outing'" class="is-nowrap is-pulled-right has-left-margin-mobile">{{ dates }}</span>
+      <span v-else> </span>
     </card-row>
 
     <card-row v-if="locale && locale.summary">
@@ -33,7 +15,25 @@
       <gallery :images="images" />
     </card-row>
 
-    <card-row v-if="documentType != 'article' && documentType != 'book'">
+    <card-row>
+      <span class="is-pulled-left">
+        <span :title="$gettext('User avatar')">
+          <img
+            v-if="!useDefaultAvatarIcon"
+            class="avatar"
+            alt="Avatar"
+            @error="useDefaultAvatarIcon = true"
+            :src="$options.forumAvatarUrl + item.user.forum_username + '/36/1_1.png'"
+            loading="lazy"
+          />
+          <fa-icon v-else icon="user" class="is-size-3 has-text-grey" />
+        </span>
+        <document-title :document="item.user" />
+      </span>
+      <span class="has-text-weight-normal">&nbsp;{{ actionLine }}</span>
+    </card-row>
+
+    <card-row v-if="documentType != 'article' && documentType != 'book' && documentType != 'xreport'">
       <span v-if="documentType === 'outing' || documentType === 'route'">
         <icon-ratings class="card-icon" />
         <document-rating :document="item.document" />
@@ -63,7 +63,7 @@
       <card-region-item :document="item.document" class="is-ellipsed" />
       <span>
         <card-activities-item v-if="item.document.activities" :activities="item.document.activities" />
-        <marker-soft-mobility v-if="documentType === 'outing' && item.document.public_transport" />
+        <marker-soft-mobility v-if="documentType === 'outing' && item.document.public_transport" class="is-size-3" />
         <marker-image-count :image-count="item.document.img_count" />
         <marker-gps-trace v-if="item.document.geometry && item.document.geometry.has_geom_detail" />
         <marker-condition v-if="documentType === 'outing'" :condition="item.document.condition_rating" />
@@ -171,6 +171,10 @@ export default {
   .has-left-margin-mobile {
     margin-left: 5px;
   }
+}
+
+.has-left-padding {
+  padding-left: 0.5rem;
 }
 
 .is-max-3-lines-height {

--- a/src/components/cards/FeedRow.vue
+++ b/src/components/cards/FeedRow.vue
@@ -114,7 +114,7 @@ export default {
       'updated xreport': this.$gettext('has updated the xreport'),
     }[[this.item['change_type'], this.documentType].join(' ')];
 
-    this.dates = this.$documentUtils.getOutingDatesLocalized(this.item['document']);
+    this.dates = this.$documentUtils.getShortOutingDatesLocalized(this.item['document']);
 
     if (this.item.image1) {
       this.images.push(this.item.image1);
@@ -136,7 +136,7 @@ export default {
   border-radius: 50%;
   width: 24px;
   height: 24px;
-  vertical-align: bottom;
+  vertical-align: middle;
   margin-right: 0.5rem;
   margin-left: 0.5rem;
 }
@@ -145,6 +145,7 @@ export default {
   transition: 0.1s;
   border: $card-border;
   background: white;
+  max-height: 3em;
 }
 
 a {
@@ -160,7 +161,6 @@ a {
 
 .row {
   display: inline-block;
-  max-height: 2em;
   max-width: 75%;
 }
 </style>

--- a/src/components/cards/FeedRow.vue
+++ b/src/components/cards/FeedRow.vue
@@ -1,68 +1,39 @@
 <template>
-  <div :document="document" class="card" :class="{ 'is-highlighted': highlighted }">
-    <span :title="$gettext('User avatar')">
-      <img
-        v-if="!useDefaultAvatarIcon"
-        class="avatar"
-        alt="Avatar"
-        @error="useDefaultAvatarIcon = true"
-        :src="$options.forumAvatarUrl + item.user.forum_username + '/36/1_1.png'"
-        loading="lazy"
-      />
-      <fa-icon v-else icon="user" class="is-size-1 has-text-grey" />
-    </span>
-    <marker-document-type :document-type="documentType" class="is-pulled-left is-size-1" />
-    <document-title :document="item.document" class="has-text-weight-bold" />
-    <span v-if="documentType === 'outing'" class="is-nowrap has-left-margin-mobile">{{ dates }}</span>
-
-    <!---
-    <card-row v-if="images.length">
-      <gallery :images="images" />
-    </card-row>
-
-    <card-row v-if="documentType != 'article' && documentType != 'book'">
-      <span v-if="documentType === 'outing' || documentType === 'route'">
-        <icon-ratings class="card-icon" />
-        <document-rating :document="item.document" />
+  <div class="card" :class="{ 'is-highlighted': highlighted }">
+    <document-link :document="document" :target="target">
+      <span :title="$gettext('User avatar')">
+        <img
+          v-if="!useDefaultAvatarIcon"
+          class="avatar"
+          alt="Avatar"
+          @error="useDefaultAvatarIcon = true"
+          :src="$options.forumAvatarUrl + item.user.forum_username + '/36/1_1.png'"
+          loading="lazy"
+        />
+        <fa-icon v-else icon="user" class="is-size-3 has-text-grey" />
       </span>
+      <marker-document-type :document-type="documentType" class="is-pulled-left is-size-3" />
 
-      <card-elevation-item :elevation="item.document.elevation_max" class="is-ellipsed" />
+      <document-title :document="item.document" class="row has-text-weight-bold is-ellipsed" />
 
-      <span v-if="item.document.height_diff_up" :title="$gettext('height_diff_up')">
-        <icon-height-diff-up />
-        {{ item.document.height_diff_up }}&nbsp;m
+      <span v-if="documentType === 'outing'">{{ dates }}</span>
+      <!-- <span v-if="item.document.areas && item.document.areas.length" class="row is-ellipsed" >
+        <card-region-item :document="item.document" />
+      </span> -->
+
+      <span class="is-pulled-right">
+        <span>
+          <card-activities-item v-if="item.document.activities" :activities="item.document.activities" />
+        </span>
+        <span>
+          <marker-soft-mobility v-if="documentType === 'outing' && item.document.public_transport" />
+          <marker-image-count :image-count="item.document.img_count" />
+          <marker-gps-trace v-if="item.document.geometry && item.document.geometry.has_geom_detail" />
+          <marker-condition v-if="documentType === 'outing'" :condition="item.document.condition_rating" />
+          <marker-quality :quality="item.document.quality" />
+        </span>
       </span>
-
-      <span v-if="item.document.height_diff_difficulties" :title="$gettext('height_diff_difficulties')">
-        <fa-icon icon="arrows-alt-v" />
-        {{ item.document.height_diff_difficulties }}&nbsp;m
-      </span>
-
-      <card-elevation-item v-if="item.document.elevation" :elevation="item.document.elevation" />
-
-    </card-row>
--->
-
-    <span v-if="item.document.areas && item.document.areas.length">
-      <card-region-item :document="item.document" />
-    </span>
-
-    <span>
-      <span>
-        <card-activities-item v-if="item.document.activities" :activities="item.document.activities" />
-      </span>
-      <span>
-        <marker-soft-mobility v-if="documentType === 'outing' && item.document.public_transport" />
-        &nbsp;
-        <marker-image-count :image-count="item.document.img_count" />
-        &nbsp;
-        <marker-gps-trace v-if="item.document.geometry && item.document.geometry.has_geom_detail" />
-      </span>
-      <span>
-        <marker-condition v-if="documentType === 'outing'" :condition="item.document.condition_rating" />
-        <marker-quality :quality="item.document.quality" />
-      </span>
-    </span>
+    </document-link>
   </div>
 </template>
 
@@ -88,6 +59,10 @@ export default {
     highlighted: {
       type: Boolean,
       default: false,
+    },
+    target: {
+      type: String,
+      default: undefined,
     },
   },
 
@@ -157,56 +132,13 @@ export default {
 </script>
 
 <style scoped lang="scss">
-/*@media screen and (max-width: $tablet) {
- .feed-card {
-    border-left: 0 !important;
-    border-right: 0 !important;
-  }
-  .has-left-margin-mobile {
-    margin-left: 5px;
-  }
-}*/
-
-.is-max-3-lines-height {
-  // proprietary stuff, supported on limited browsers
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.card-image-content {
-  display: flex;
-  overflow: hidden;
-}
-
 .avatar {
   border-radius: 50%;
-  width: 36px;
-  height: 36px;
+  width: 24px;
+  height: 24px;
   vertical-align: bottom;
   margin-right: 0.5rem;
   margin-left: 0.5rem;
-}
-
-.has-3-images > div {
-  width: 33.33%;
-  max-height: 275px;
-  overflow: hidden;
-}
-
-.has-2-images > div {
-  width: 50%;
-}
-
-.has-2-images > div {
-  width: 100%;
-}
-
-.card-image-content > div > img {
-  width: 100%;
-  box-sizing: border-box;
 }
 
 .card {
@@ -215,10 +147,20 @@ export default {
   background: white;
 }
 
+a {
+  color: #363636 !important;
+}
+
 .card:hover,
 .is-highlighted {
   transition: 0.2s;
   box-shadow: $card-hover-shadow;
   background: $hover-background;
+}
+
+.row {
+  display: inline-block;
+  max-height: 2em;
+  max-width: 75%;
 }
 </style>

--- a/src/components/cards/FeedRow.vue
+++ b/src/components/cards/FeedRow.vue
@@ -1,34 +1,21 @@
 <template>
-  <card-container :document="document">
-    <card-title>
-      <span :title="$gettext('User avatar')">
-        <img
-          v-if="!useDefaultAvatarIcon"
-          class="avatar"
-          alt="Avatar"
-          @error="useDefaultAvatarIcon = true"
-          :src="$options.forumAvatarUrl + item.user.forum_username + '/36/1_1.png'"
-          loading="lazy"
-        />
-        <fa-icon v-else icon="user" class="is-size-3 has-text-grey" />
-      </span>
-      <span>
-        <document-title :document="item.user" />
-        <span class="has-text-weight-normal">&nbsp;{{ actionLine }}</span>
-      </span>
+  <div :document="document" class="card" :class="{ 'is-highlighted': highlighted }">
+    <span :title="$gettext('User avatar')">
+      <img
+        v-if="!useDefaultAvatarIcon"
+        class="avatar"
+        alt="Avatar"
+        @error="useDefaultAvatarIcon = true"
+        :src="$options.forumAvatarUrl + item.user.forum_username + '/36/1_1.png'"
+        loading="lazy"
+      />
+      <fa-icon v-else icon="user" class="is-size-1 has-text-grey" />
+    </span>
+    <marker-document-type :document-type="documentType" class="is-pulled-left is-size-1" />
+    <document-title :document="item.document" class="has-text-weight-bold" />
+    <span v-if="documentType === 'outing'" class="is-nowrap has-left-margin-mobile">{{ dates }}</span>
 
-      <marker-document-type :document-type="documentType" class="is-pulled-right is-size-3" />
-    </card-title>
-
-    <card-row>
-      <document-title :document="item.document" class="has-text-weight-bold" />
-      <span v-if="documentType === 'outing'" class="is-nowrap has-left-margin-mobile">{{ dates }}</span>
-    </card-row>
-
-    <card-row v-if="locale && locale.summary">
-      <p class="is-max-3-lines-height">{{ locale.summary | stripMarkdown | max300chars }}</p>
-    </card-row>
-
+    <!---
     <card-row v-if="images.length">
       <gallery :images="images" />
     </card-row>
@@ -53,17 +40,14 @@
 
       <card-elevation-item v-if="item.document.elevation" :elevation="item.document.elevation" />
 
-      <span v-if="item.document.waypoint_type">
-        <icon-waypoint-type :waypoint-type="item.document.waypoint_type" />
-        <span>{{ $gettext(item.document.waypoint_type, 'waypoint_types') | uppercaseFirstLetter }}</span>
-      </span>
     </card-row>
+-->
 
-    <card-row v-if="item.document.areas && item.document.areas.length">
+    <span v-if="item.document.areas && item.document.areas.length">
       <card-region-item :document="item.document" />
-    </card-row>
+    </span>
 
-    <card-row>
+    <span>
       <span>
         <card-activities-item v-if="item.document.activities" :activities="item.document.activities" />
       </span>
@@ -74,25 +58,21 @@
         &nbsp;
         <marker-gps-trace v-if="item.document.geometry && item.document.geometry.has_geom_detail" />
       </span>
-      <span> {{ $dateUtils.timeAgo(item.time) }} </span>
       <span>
         <marker-condition v-if="documentType === 'outing'" :condition="item.document.condition_rating" />
         <marker-quality :quality="item.document.quality" />
       </span>
-    </card-row>
-  </card-container>
+    </span>
+  </div>
 </template>
 
 <script>
 import { cardMixin } from './utils/mixins';
 
-import Gallery from '@/components/gallery/Gallery';
 import forum from '@/js/apis/forum';
 
 export default {
-  components: {
-    Gallery,
-  },
+  components: {},
 
   filters: {
     max300chars: (value) => (value.length > 300 ? value.substring(0, 300) + '…' : value),
@@ -104,6 +84,10 @@ export default {
     item: {
       type: Object,
       required: true,
+    },
+    highlighted: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -173,15 +157,15 @@ export default {
 </script>
 
 <style scoped lang="scss">
-@media screen and (max-width: $tablet) {
-  .feed-card {
+/*@media screen and (max-width: $tablet) {
+ .feed-card {
     border-left: 0 !important;
     border-right: 0 !important;
   }
   .has-left-margin-mobile {
     margin-left: 5px;
   }
-}
+}*/
 
 .is-max-3-lines-height {
   // proprietary stuff, supported on limited browsers
@@ -203,6 +187,7 @@ export default {
   height: 36px;
   vertical-align: bottom;
   margin-right: 0.5rem;
+  margin-left: 0.5rem;
 }
 
 .has-3-images > div {
@@ -222,5 +207,18 @@ export default {
 .card-image-content > div > img {
   width: 100%;
   box-sizing: border-box;
+}
+
+.card {
+  transition: 0.1s;
+  border: $card-border;
+  background: white;
+}
+
+.card:hover,
+.is-highlighted {
+  transition: 0.2s;
+  box-shadow: $card-hover-shadow;
+  background: $hover-background;
 }
 </style>

--- a/src/components/feed-widget/FeedTab.vue
+++ b/src/components/feed-widget/FeedTab.vue
@@ -189,6 +189,6 @@ export default {
 
 <style scoped lang="scss">
 .feed-card {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.2rem;
 }
 </style>

--- a/src/components/feed-widget/FeedTab.vue
+++ b/src/components/feed-widget/FeedTab.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="columns" v-infinite-scroll="load" infinite-scroll-disabled="loading" infinite-scroll-distance="500">
     <div v-for="(column, i) of columns" :key="i" :class="'column ' + cssColumnsClass">
-      <feed-card v-for="item of column.items" :key="item.id" :item="item" class="feed-card" />
+      <feed-row v-for="item of column.items" :key="item.id" :item="item" class="feed-card" />
     </div>
     <!-- <loading-notification :promise="promise" /> -->
   </div>
@@ -10,12 +10,12 @@
 <script>
 import infiniteScroll from 'vue-infinite-scroll';
 
-import FeedCard from '@/components/cards/FeedCard';
+import FeedRow from '@/components/cards/FeedRow';
 import c2c from '@/js/apis/c2c';
 
 export default {
   components: {
-    FeedCard,
+    FeedRow,
   },
 
   directives: { infiniteScroll },
@@ -79,30 +79,9 @@ export default {
     },
 
     initializeColumns() {
-      const availableWidth = this.$el.clientWidth;
-      const cardLargestWidth = 400;
-
       let columnCount;
-
-      if (availableWidth < 2 * cardLargestWidth) {
-        this.cssColumnsClass = 'is-full';
-        columnCount = 1;
-      } else if (availableWidth < 3 * cardLargestWidth) {
-        this.cssColumnsClass = 'is-half';
-        columnCount = 2;
-      } else if (availableWidth < 4 * cardLargestWidth) {
-        this.cssColumnsClass = 'is-one-third';
-        columnCount = 3;
-      } else if (availableWidth < 5 * cardLargestWidth) {
-        this.cssColumnsClass = 'is-one-quarter';
-        columnCount = 4;
-      } else if (availableWidth < 6 * cardLargestWidth) {
-        this.cssColumnsClass = 'is-two-fifths';
-        columnCount = 5;
-      } else {
-        this.cssColumnsClass = 'is-2';
-        columnCount = 6;
-      }
+      this.cssColumnsClass = 'is-full';
+      columnCount = 1;
 
       this.columns = [];
 
@@ -210,6 +189,6 @@ export default {
 
 <style scoped lang="scss">
 .feed-card {
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.5rem;
 }
 </style>

--- a/src/components/feed-widget/FeedWidget.vue
+++ b/src/components/feed-widget/FeedWidget.vue
@@ -80,7 +80,7 @@ export default {
 
     initializeColumns() {
       const availableWidth = this.$el.clientWidth;
-      const cardLargestWidth = 400;
+      const cardLargestWidth = 350; //400 de base
 
       let columnCount;
 
@@ -210,6 +210,6 @@ export default {
 
 <style scoped lang="scss">
 .feed-card {
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.75rem;
 }
 </style>

--- a/src/js/vue-plugins/document-utils.js
+++ b/src/js/vue-plugins/document-utils.js
@@ -304,6 +304,31 @@ export default function install(Vue) {
         }
       },
 
+      getShortOutingDatesLocalized(document) {
+        // date_end may be empty on outing creation
+        // it will be filled on save
+        // so, for the preview, we must replace an empty date_end with date start
+        const date_start = document.date_start;
+        const date_end = document.date_end || date_start;
+
+        if (!date_start) {
+          return this.$gettext('Invalid date');
+        }
+
+        const start = this.$dateUtils.parseDate(date_start);
+        const end = this.$dateUtils.parseDate(date_end);
+
+        if (!isSameYear(start, end)) {
+          return this.formatDate(start, 'P') + ' - ' + this.formatDate(end, 'd');
+        } else if (!isSameMonth(start, end)) {
+          return this.formatDate(start, 'd MM') + ' - ' + this.formatDate(end, 'P');
+        } else if (!isSameDay(start, end)) {
+          return this.formatDate(start, 'd') + ' - ' + this.formatDate(end, 'P');
+        } else {
+          return this.formatDate(end, 'P');
+        }
+      },
+
       formatDate(arg, formatString) {
         return format(arg, formatString, { locale: locales[this.$language.current] });
       },

--- a/src/views/portals/FeedView.vue
+++ b/src/views/portals/FeedView.vue
@@ -23,7 +23,7 @@
                 Personal feed
               </label>
             </div>
-            <span @click="toogleProperty('listMode')" class="header-item is-size-3 has-cursor-pointer is-hidden-mobile">
+            <span @click="toogleProperty('listMode')" class="header-item is-size-3 has-cursor-pointer">
               <fa-icon icon="th-list" :class="listMode ? 'has-text-primary' : ''" :title="$gettext('List mode')" />
               <fa-icon icon="th" :class="!listMode ? 'has-text-primary' : ''" :title="$gettext('Cards mode')" />
             </span>

--- a/src/views/portals/FeedView.vue
+++ b/src/views/portals/FeedView.vue
@@ -23,8 +23,23 @@
                 Personal feed
               </label>
             </div>
+            <span @click="toogleProperty('listMode')" class="header-item is-size-3 has-cursor-pointer is-hidden-mobile">
+              <fa-icon icon="th-list" :class="listMode ? 'has-text-primary' : ''" :title="$gettext('List mode')" />
+              <fa-icon icon="th" :class="!listMode ? 'has-text-primary' : ''" :title="$gettext('Cards mode')" />
+            </span>
           </div>
-          <feed-widget :type="isPersonal && $user.isLogged ? 'personal' : 'default'" hide-empty-documents />
+          <feed-widget
+            v-if="!listMode"
+            :type="isPersonal && $user.isLogged ? 'personal' : 'default'"
+            hide-empty-documents
+            hide-waypoints
+          />
+          <feed-tab
+            v-if="listMode"
+            :type="isPersonal && $user.isLogged ? 'personal' : 'default'"
+            hide-empty-documents
+            hide-waypoints
+          />
         </div>
         <div
           v-if="!$screen.isMobile"
@@ -42,6 +57,7 @@
 import HomeBanner from './HomeBanner';
 import ForumWidget from './utils/ForumWidget';
 
+import FeedTab from '@/components/feed-widget/FeedTab';
 import FeedWidget from '@/components/feed-widget/FeedWidget';
 
 export default {
@@ -49,6 +65,7 @@ export default {
 
   components: {
     HomeBanner,
+    FeedTab,
     FeedWidget,
     ForumWidget,
   },
@@ -56,6 +73,7 @@ export default {
   data() {
     return {
       isPersonal: false,
+      listMode: false,
     };
   },
 
@@ -66,6 +84,15 @@ export default {
   methods: {
     saveIsPersonalState() {
       this.$localStorage.set('isPersonal', this.isPersonal);
+    },
+
+    toogleProperty(property) {
+      this.setProperty(property, !this[property]);
+    },
+
+    setProperty(property, value) {
+      this[property] = value;
+      this.$localStorage.set(`${this.documentType}.${property}`, this[property]);
     },
   },
 };

--- a/src/views/portals/utils/ForumWidget.vue
+++ b/src/views/portals/utils/ForumWidget.vue
@@ -168,7 +168,7 @@ export default {
 
 .wide {
   .forum-row {
-    padding: 1rem;
+    padding: 0.5rem;
     border-bottom: 1px solid #eee;
 
     img {


### PR DESCRIPTION
[On forum](https://forum.camptocamp.org/t/look-de-la-page-daccueil/241462/261)

- Optimize card's size for certains resolutions, in order to see more without scrolling
- Working on the presentation of the cards and their content
- Author and age of card informations should be less visible
- After visiting a link, user should be resume where he left his reading
- Do not show waypoints
- Do not show outings done x weeks before (x to be defined)
- Do not show-up when adding photos (timing ?) on outing
- Do not show-up when a new user is associated on outing
- Do not show-up when a second user add photos on outing
- Add possibility to choose between cards and list
- Let user choose the photos to be shown in feed (3 first images from the last downloading)
- Use quality field to show old outings (to be defined)