### PR TITLE
feat(statistics): fix NaN when there is no outing yet

### DIFF
--- a/src/views/portals/outings-stats/OutingsStatsView.vue
+++ b/src/views/portals/outings-stats/OutingsStatsView.vue
@@ -73,7 +73,11 @@ export default {
     },
 
     progress(current, total) {
-      this.loadingPercentage = current / Math.min(total, LIST_MAX_LENGTH);
+      if (!total) {
+        this.loadingPercentage = 0;
+      } else {
+        this.loadingPercentage = current / Math.min(total, LIST_MAX_LENGTH);
+      }
     },
 
     compute(outings) {

--- a/src/views/portals/outings-stats/OutingsStatsView.vue
+++ b/src/views/portals/outings-stats/OutingsStatsView.vue
@@ -74,7 +74,8 @@ export default {
 
     progress(current, total) {
       if (!total) {
-        this.loadingPercentage = 0;
+        // when there are no outings, we do show "all" of them
+        this.loadingPercentage = 1;
       } else {
         this.loadingPercentage = current / Math.min(total, LIST_MAX_LENGTH);
       }


### PR DESCRIPTION
Saw this 
<img width="325" alt="Screenshot 2022-10-24 at 14 48 31" src="https://user-images.githubusercontent.com/3254314/197531651-dcf52bbe-bf78-4539-9581-23a3d349c2a2.png">
and decided to fix it directly