### PR TITLE
Correctly display f-number and exposure time

### DIFF
--- a/src/components/generics/DocumentField.vue
+++ b/src/components/generics/DocumentField.vue
@@ -27,7 +27,10 @@
  --><span v-else-if="field.i18n">{{ $gettext(value, field.i18nContext) }} </span
     ><!--
 
- --><span v-else>{{ divisor ? Math.round(value / divisor) : value }}</span
+ --><span v-else
+      ><span v-if="showPrefix">{{ prefix || field.prefix }}</span
+      ><!--
+    -->{{ divisor ? Math.round(value / divisor) : value }}</span
     ><!--
     --><span v-if="showUnit && !field.skipSpaceBeforeUnit">&nbsp;</span
     ><!--
@@ -54,6 +57,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    prefix: {
+      type: String,
+      default: null,
+    },
   },
 
   computed: {
@@ -67,6 +74,10 @@ export default {
 
     showUnit() {
       return (this.unit || this.field.unit) && this.value !== null && this.value !== undefined;
+    },
+
+    showPrefix() {
+      return (this.prefix || this.field.prefix) && this.value !== null && this.value !== undefined;
     },
   },
 };

--- a/src/js/constants/fieldsProperties.json
+++ b/src/js/constants/fieldsProperties.json
@@ -331,7 +331,8 @@
     "disabled": true
   },
   "fnumber": {
-    "type": "text"
+    "type": "number",
+    "prefix": "f/"
   },
   "focal_length": {
     "type": "number",

--- a/src/js/constants/fieldsProperties.json
+++ b/src/js/constants/fieldsProperties.json
@@ -316,7 +316,7 @@
     "type": "number",
     "min": 0,
     "max": 0,
-    "unit": "ms"
+    "unit": "s"
   },
   "external_resources": {
     "type": "markdown",

--- a/src/views/document/utils/field-viewers/FieldView.vue
+++ b/src/views/document/utils/field-viewers/FieldView.vue
@@ -5,6 +5,7 @@
       :field="field"
       :unit="unit || field.unit"
       :divisor="divisor"
+      :prefix="prefix"
       :sort-values="sortValues"
     />
   </label-value>
@@ -27,6 +28,10 @@ export default {
     },
     divisor: {
       type: Number,
+      default: null,
+    },
+    prefix: {
+      type: String,
       default: null,
     },
     context: {


### PR DESCRIPTION
Currently, an error is thrown on image view when trying to display the f-number
(see for example https://www.camptocamp.org/images/1438128/fr/ and look at the console)

This PR fixes the error by expliciting that the fnumber is a number (!) and should not be translated. It also adds a "prefix" option for field properties in order to display "f/2" for example.

PS: the translation for fnumber in french is "Propriétés de l'image", which is incorrect (Should be "Ouverture"). I reported an issue in transifex, but I'm not used to the tool, and didn't check the other languages.