### PR TITLE
fix: avoid date inconsistency for several days outing

### DIFF
--- a/src/views/wiki/edition/OutingEditionView.vue
+++ b/src/views/wiki/edition/OutingEditionView.vue
@@ -403,11 +403,15 @@ export default {
     handleDates() {
       if (!this.showBothDates) {
         this.document.date_end = this.document.date_start;
+      } else if (this.document.date_end < this.document.date_start) {
+        this.document.date_end = this.document.date_start;
       }
     },
+
     setCurrentDate() {
       this.currentDate = getCurrentDateString();
     },
+
     beforeSave() {
       this.handleDates();
       this.$refs.qualityField.beforeSave();


### PR DESCRIPTION
One could check `several days`, uncheck it, change start date to a later value, check again `several days` and have end date initialized with previous start date, thus before current start date