### PR TITLE
Add no follow on print button

### DIFF
--- a/src/views/documents/utils/PrintButton.vue
+++ b/src/views/documents/utils/PrintButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <router-link target="_blank" :to="path">
+  <router-link target="_blank" :to="path" rel="nofollow">
     <button class="button is-primary is-size-7-mobile">
       <fa-icon icon="print"></fa-icon>
       <span class="is-hidden-touch">&nbsp;</span>


### PR DESCRIPTION
Print pages shows up in google results (see screenshot).

Add `rel="nofollow"` on print button.

![image](https://user-images.githubusercontent.com/11915659/205106105-0c3602a9-6048-4989-8a15-84178af2c131.png)
