### PR TITLE
Support webp and avif format via <picture>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "c2c_ui",
       "version": "7.14.0",
+      "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@brunobesson/vue-awesome-swiper": "4.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "eslint-plugin-promise": "5.2.0",
         "eslint-plugin-vue": "7.20.0",
         "husky": "8.0.3",
+        "patch-package": "6.5.0",
         "postcss-html": "1.5.0",
         "prettier": "2.8.2",
         "pretty-quick": "3.1.3",
@@ -3312,6 +3313,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
+    },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -7192,6 +7199,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -8609,6 +8625,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/klona": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
@@ -9923,6 +9948,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -10069,6 +10103,259 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.0.tgz",
+      "integrity": "sha512-tC3EqJmo74yKqfsMzELaFwxOAu6FH6t+FzFOsnWAuARm7/n2xB5AOeOueE221eM9gtMuIKMKpF9tBy/X2mNP0Q==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^1.10.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "node_modules/patch-package/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/patch-package/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/path-exists": {
@@ -12898,6 +13185,18 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -16761,6 +17060,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -19636,6 +19941,15 @@
         "path-exists": "^4.0.0"
       }
     },
+    "find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -20653,6 +20967,15 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "klona": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
@@ -21654,6 +21977,12 @@
         }
       }
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -21772,6 +22101,194 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "patch-package": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.0.tgz",
+      "integrity": "sha512-tC3EqJmo74yKqfsMzELaFwxOAu6FH6t+FzFOsnWAuARm7/n2xB5AOeOueE221eM9gtMuIKMKpF9tBy/X2mNP0Q==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "open": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+          "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+          "dev": true,
+          "requires": {
+            "is-docker": "^2.0.0",
+            "is-wsl": "^2.1.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "path-exists": {
@@ -23798,6 +24315,15 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "messages:extract": "node tools/extract-messages.js",
     "prepare": "husky install && npm run snyk-protect",
     "snyk-protect": "snyk-protect",
-    "update-c2c-common": "python3 tools/update-c2c-common.py"
+    "update-c2c-common": "python3 tools/update-c2c-common.py",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@brunobesson/vue-awesome-swiper": "4.1.4",
@@ -72,6 +73,7 @@
     "eslint-plugin-promise": "5.2.0",
     "eslint-plugin-vue": "7.20.0",
     "husky": "8.0.3",
+    "patch-package": "6.5.0",
     "postcss-html": "1.5.0",
     "prettier": "2.8.2",
     "pretty-quick": "3.1.3",

--- a/patches/swiper+6.8.4.patch
+++ b/patches/swiper+6.8.4.patch
@@ -10,7 +10,7 @@ index e5d87a6..d148e7f 100644
 +    if (callback) {
 +      setTimeout(() => {
 +        callback();
-+      }, 100);
++      }, 0);
 +    }
    }
  

--- a/patches/swiper+6.8.4.patch
+++ b/patches/swiper+6.8.4.patch
@@ -1,0 +1,60 @@
+diff --git a/node_modules/swiper/esm/components/core/images/loadImage.js b/node_modules/swiper/esm/components/core/images/loadImage.js
+index e5d87a6..d148e7f 100644
+--- a/node_modules/swiper/esm/components/core/images/loadImage.js
++++ b/node_modules/swiper/esm/components/core/images/loadImage.js
+@@ -5,12 +5,14 @@ export default function loadImage(imageEl, src, srcset, sizes, checkForComplete,
+   var image;
+ 
+   function onReady() {
+-    if (callback) callback();
++    if (callback) {
++      setTimeout(() => {
++        callback();
++      }, 100);
++    }
+   }
+ 
+-  var isPicture = $(imageEl).parent('picture')[0];
+-
+-  if (!isPicture && (!imageEl.complete || !checkForComplete)) {
++  if (!imageEl.complete || !checkForComplete) {
+     if (src) {
+       image = new window.Image();
+       image.onload = onReady;
+diff --git a/node_modules/swiper/esm/components/zoom/zoom.js b/node_modules/swiper/esm/components/zoom/zoom.js
+index 539004a..53a6386 100644
+--- a/node_modules/swiper/esm/components/zoom/zoom.js
++++ b/node_modules/swiper/esm/components/zoom/zoom.js
+@@ -36,8 +36,8 @@ var Zoom = {
+     if (!gesture.$slideEl || !gesture.$slideEl.length) {
+       gesture.$slideEl = $(e.target).closest("." + swiper.params.slideClass);
+       if (gesture.$slideEl.length === 0) gesture.$slideEl = swiper.slides.eq(swiper.activeIndex);
+-      gesture.$imageEl = gesture.$slideEl.find('img, svg, canvas, picture, .swiper-zoom-target');
+-      gesture.$imageWrapEl = gesture.$imageEl.parent("." + params.containerClass);
++      gesture.$imageEl = gesture.$slideEl.find('img, svg, canvas, .swiper-zoom-target');
++      gesture.$imageWrapEl = gesture.$imageEl.closest("." + params.containerClass);
+       gesture.maxRatio = gesture.$imageWrapEl.attr('data-swiper-zoom') || params.maxRatio;
+ 
+       if (gesture.$imageWrapEl.length === 0) {
+@@ -305,8 +305,8 @@ var Zoom = {
+         }
+       }
+ 
+-      gesture.$imageEl = gesture.$slideEl.find('img, svg, canvas, picture, .swiper-zoom-target');
+-      gesture.$imageWrapEl = gesture.$imageEl.parent("." + params.containerClass);
++      gesture.$imageEl = gesture.$slideEl.find('img, svg, canvas, .swiper-zoom-target');
++      gesture.$imageWrapEl = gesture.$imageEl.closest("." + params.containerClass);
+     }
+ 
+     if (!gesture.$imageEl || gesture.$imageEl.length === 0 || !gesture.$imageWrapEl || gesture.$imageWrapEl.length === 0) return;
+@@ -395,8 +395,8 @@ var Zoom = {
+         gesture.$slideEl = swiper.slides.eq(swiper.activeIndex);
+       }
+ 
+-      gesture.$imageEl = gesture.$slideEl.find('img, svg, canvas, picture, .swiper-zoom-target');
+-      gesture.$imageWrapEl = gesture.$imageEl.parent("." + params.containerClass);
++      gesture.$imageEl = gesture.$slideEl.find('img, svg, canvas, .swiper-zoom-target');
++      gesture.$imageWrapEl = gesture.$imageEl.closest("." + params.containerClass);
+     }
+ 
+     if (!gesture.$imageEl || gesture.$imageEl.length === 0 || !gesture.$imageWrapEl || gesture.$imageWrapEl.length === 0) return;

--- a/src/components/association-editor/AssociationImageLink.vue
+++ b/src/components/association-editor/AssociationImageLink.vue
@@ -1,7 +1,7 @@
 <template>
   <document-link :document="image" class="has-hover-background" target="_blank">
     <figure class="image is-96x96 association-image-link-child">
-      <img :src="getUrl(image)" :title="image.locales[0].title" :alt="image.locales[0].title" loading="lazy" />
+      <thumbnail :img="image" size="SI" :title="image.locales[0].title" :alt="image.locales[0].title" loading="lazy" />
     </figure>
     <span class="association-image-link-child">
       {{ image.locales[0].title | max50chars }}
@@ -10,8 +10,6 @@
 </template>
 
 <script>
-import imageUrls from '@/js/image-urls';
-
 export default {
   filters: {
     max50chars: (value) => (value && value.length > 50 ? value.substring(0, 50) + '…' : value),
@@ -21,12 +19,6 @@ export default {
     image: {
       type: Object,
       required: true,
-    },
-  },
-
-  methods: {
-    getUrl(image) {
-      return imageUrls.getSquared(image);
     },
   },
 };

--- a/src/components/gallery/Gallery.vue
+++ b/src/components/gallery/Gallery.vue
@@ -1,8 +1,9 @@
 <template>
   <swiper :options="$options.swiperOption" class="swiper">
     <swiper-slide v-for="image of images" :key="image.document_id">
-      <img
-        :src="getUrl(image)"
+      <thumbnail
+        :img="image"
+        size="MI"
         :alt="image.locales[0].title"
         :title="image.locales[0].title"
         @click="$imageViewer.show(image)"
@@ -15,8 +16,6 @@
 <script>
 import getAwesomeSwiper from '@brunobesson/vue-awesome-swiper/dist/exporter';
 import { Swiper as SwiperClass } from 'swiper/core';
-
-import imageUrls from '@/js/image-urls';
 
 const { Swiper, SwiperSlide } = getAwesomeSwiper(SwiperClass);
 
@@ -43,12 +42,6 @@ export default {
     this.images.forEach(this.$imageViewer.push);
   },
 
-  methods: {
-    getUrl(image) {
-      return imageUrls.getMedium(image);
-    },
-  },
-
   swiperOption: {
     slidesPerView: 'auto',
     spaceBetween: 15,
@@ -68,7 +61,7 @@ export default {
     width: auto;
     cursor: pointer;
 
-    img {
+    picture::v-deep img {
       height: 200px;
     }
   }

--- a/src/components/generics/Markdown.vue
+++ b/src/components/generics/Markdown.vue
@@ -121,8 +121,9 @@ export default {
 
     computeImages(images) {
       for (const image of images) {
+        const document_id = parseInt(image.attributes['c2c:document-id'].value, 10);
         image.c2cExtrapoledDocument = {
-          document_id: parseInt(image.attributes['c2c:document-id'].value, 10),
+          document_id,
           locales: [{ title: '...' }],
           available_langs: [this.$language.current],
           type: 'i',
@@ -133,7 +134,25 @@ export default {
           this.$imageViewer.show(image.c2cExtrapoledDocument);
         });
 
-        this.$imageViewer.push(image.c2cExtrapoledDocument);
+        const parent = image.parentNode;
+        const picture = document.createElement('picture');
+
+        // Until all images are migrated only images uploaded after a given timestamp
+        // or with an id greater than a given one have their webp and avif versions
+        if (config.urls.modernThumbnailsId && document_id > config.urls.modernThumbnailsId) {
+          const avif = document.createElement('source');
+          avif.setAttribute('type', 'image/avif');
+          avif.setAttribute('srcset', config.urls.api + image.attributes['c2c:url-proxy'].value + '&format=avif');
+          const webp = document.createElement('source');
+          webp.setAttribute('type', 'image/webp');
+          webp.setAttribute('srcset', config.urls.api + image.attributes['c2c:url-proxy'].value + '&format=webp');
+          picture.appendChild(avif);
+          picture.appendChild(webp);
+        }
+        picture.appendChild(image);
+        parent.appendChild(picture, image);
+
+        this.$imageViewer.push(image.c2cExtrapoledDocument); // TODO:
       }
     },
 

--- a/src/components/generics/Markdown.vue
+++ b/src/components/generics/Markdown.vue
@@ -142,17 +142,17 @@ export default {
         if (config.urls.modernThumbnailsId && document_id > config.urls.modernThumbnailsId) {
           const avif = document.createElement('source');
           avif.setAttribute('type', 'image/avif');
-          avif.setAttribute('srcset', config.urls.api + image.attributes['c2c:url-proxy'].value + '&format=avif');
+          avif.setAttribute('srcset', config.urls.api + image.attributes['c2c:url-proxy'].value + '&extension=avif');
           const webp = document.createElement('source');
           webp.setAttribute('type', 'image/webp');
-          webp.setAttribute('srcset', config.urls.api + image.attributes['c2c:url-proxy'].value + '&format=webp');
+          webp.setAttribute('srcset', config.urls.api + image.attributes['c2c:url-proxy'].value + '&extension=webp');
           picture.appendChild(avif);
           picture.appendChild(webp);
         }
         picture.appendChild(image);
         parent.appendChild(picture, image);
 
-        this.$imageViewer.push(image.c2cExtrapoledDocument); // TODO:
+        this.$imageViewer.push(image.c2cExtrapoledDocument);
       }
     },
 

--- a/src/components/generics/Thumbnail.vue
+++ b/src/components/generics/Thumbnail.vue
@@ -33,6 +33,8 @@ export default {
     },
   },
   methods: {
+    // In case the "modern" thumbnail is not available, be sure
+    // to switch to the "basic" version.
     onError(event) {
       if (this.avif) {
         const img = event.target;

--- a/src/components/generics/Thumbnail.vue
+++ b/src/components/generics/Thumbnail.vue
@@ -2,7 +2,7 @@
   <picture>
     <source v-if="avif" type="image/avif" :srcset="avif" />
     <source v-if="webp" type="image/webp" :srcset="webp" />
-    <img v-bind="$attrs" :src="standard" />
+    <img v-bind="$attrs" v-on="$listeners" :src="standard" />
   </picture>
 </template>
 

--- a/src/components/generics/Thumbnail.vue
+++ b/src/components/generics/Thumbnail.vue
@@ -1,0 +1,36 @@
+<template>
+  <picture>
+    <source v-if="avif" type="image/avif" :srcset="avif" />
+    <source v-if="webp" type="image/webp" :srcset="webp" />
+    <img v-bind="$attrs" :src="standard" />
+  </picture>
+</template>
+
+<script>
+import { getImageUrl } from '@/js/image-urls';
+
+export default {
+  inheritAttrs: false,
+  props: {
+    img: {
+      type: Object,
+      required: true,
+    },
+    size: {
+      type: String,
+      default: null,
+    },
+  },
+  computed: {
+    avif() {
+      return getImageUrl(this.img, this.size, 'avif');
+    },
+    webp() {
+      return getImageUrl(this.img, this.size, 'webp');
+    },
+    standard() {
+      return getImageUrl(this.img, this.size);
+    },
+  },
+};
+</script>

--- a/src/components/generics/Thumbnail.vue
+++ b/src/components/generics/Thumbnail.vue
@@ -2,7 +2,7 @@
   <picture>
     <source v-if="avif" type="image/avif" :srcset="avif" />
     <source v-if="webp" type="image/webp" :srcset="webp" />
-    <img v-bind="$attrs" v-on="$listeners" :src="standard" />
+    <img ref="img" v-bind="$attrs" v-on="$listeners" :src="standard" @error.once="onError" />
   </picture>
 </template>
 
@@ -30,6 +30,14 @@ export default {
     },
     standard() {
       return getImageUrl(this.img, this.size);
+    },
+  },
+  methods: {
+    onError(event) {
+      if (this.avif) {
+        const img = event.target;
+        img.parentNode.children[0].srcset = img.parentNode.children[1].srcset = img.src;
+      }
     },
   },
 };

--- a/src/components/image-viewer/ImageViewer.vue
+++ b/src/components/image-viewer/ImageViewer.vue
@@ -152,7 +152,7 @@ export default {
                   <div class="swiper-zoom-container">
                   <picture>
                     ${avifSrc ? `<source type="image/avif" data-srcset="${avifSrc}">` : ''}
-                    ${webpSrc ? `<source type="image/avif" data-srcset="${webpSrc}">` : ''}
+                    ${webpSrc ? `<source type="image/webp" data-srcset="${webpSrc}">` : ''}
                     <img
                       data-src="${imgSrc}"
                       class="swiper-lazy"

--- a/src/components/image-viewer/ImageViewer.vue
+++ b/src/components/image-viewer/ImageViewer.vue
@@ -57,7 +57,7 @@ import ZingTouch from 'zingtouch';
 
 import ImageInfo from './ImageInfo';
 
-import imageUrls from '@/js/image-urls';
+import { getImageUrl } from '@/js/image-urls';
 
 SwiperCore.use([Keyboard, Lazy, Navigation, Pagination, Virtual, Zoom]);
 
@@ -140,16 +140,25 @@ export default {
           // https://swiperjs.com/api/#virtual
           // loop: true,
 
-          // virtual because it may be too slow if there is too many image
+          // virtual because it may be too slow if there are too many image
           // test : https://c2corg.github.io/c2c_ui/#/articles/1058594/fr/concours-photo-sophie-2018
           virtual: {
             slides,
             renderSlide(img) {
+              const avifSrc = getImageUrl(img, 'BI', 'avif');
+              const webpSrc = getImageUrl(img, 'BI', 'webp');
+              const imgSrc = getImageUrl(img, 'BI');
               return `<div class="swiper-slide image-viewer-slide" style="{left:${this.offset}px}">
                   <div class="swiper-zoom-container">
-                    <img data-src="${imageUrls.getBig(img)}" class="swiper-lazy" alt="${
-                img.locales[0].title
-              }" loading="lazy">
+                  <picture>
+                    ${avifSrc ? `<source type="image/avif" data-srcset="${avifSrc}">` : ''}
+                    ${webpSrc ? `<source type="image/avif" data-srcset="${webpSrc}">` : ''}
+                    <img
+                      data-src="${imgSrc}"
+                      class="swiper-lazy"
+                      alt="${img.locales[0].title}"
+                      loading="lazy">
+                  </picture>
                   </div>
                   <div class="swiper-lazy-preloader swiper-lazy-preloader-white"/>
                 </div>`;

--- a/src/js/image-urls.js
+++ b/src/js/image-urls.js
@@ -32,7 +32,7 @@ export const getImageUrl = function (image, size, format) {
       if (!config.urls.modernThumbnailsTimestamp || timestamp < config.urls.modernThumbnailsTimestamp) {
         return;
       }
-      return backendFilename.substring(0, backendFilename.length - 3) + format;
+      return `${config.urls.media}/${backendFilename.substring(0, backendFilename.length - 3) + format}`;
     }
   } else {
     backendFilename = image.filename;

--- a/src/js/image-urls.js
+++ b/src/js/image-urls.js
@@ -1,9 +1,20 @@
 import config from '@/js/config';
 
+const getImageProxyUrl = function (image, size, format) {
+  // Until all images are migrated only images uploaded after a given timestamp
+  // or with an id greater than a given one have their webp and avif versions
+  if (format && (!config.urls.modernThumbnailsId || image.document_id < config.urls.modernThumbnailsId)) {
+    return;
+  }
+
+  const sizeArg = size ? `?size=${size}` : '';
+  const formatArg = format && size ? `&extension=${format}` : '';
+  return `${config.urls.api}/images/proxy/${image.document_id}${sizeArg}${formatArg}`;
+};
+
 export const getImageUrl = function (image, size, format) {
   if (!image.filename) {
-    const sizeArg = size ? `?size=${size}` : '';
-    return `${config.urls.api}/images/proxy/${image.document_id}${sizeArg}`;
+    return getImageProxyUrl(image, size, format);
   }
 
   let backendFilename;

--- a/src/js/image-urls.js
+++ b/src/js/image-urls.js
@@ -1,6 +1,6 @@
 import config from '@/js/config';
 
-const getUrl = function (image, size) {
+export const getImageUrl = function (image, size, format) {
   if (!image.filename) {
     const sizeArg = size ? `?size=${size}` : '';
     return `${config.urls.api}/images/proxy/${image.document_id}${sizeArg}`;
@@ -9,32 +9,23 @@ const getUrl = function (image, size) {
   let backendFilename;
 
   if (size) {
+    if (!['SI', 'MI', 'BI'].includes(size)) {
+      throw new Error('Invalid size');
+    }
+
     backendFilename = image.filename.replace('.', `${size}.`).replace('.svg', '.jpg');
+    if (format) {
+      // Until all images are migrated only images uploaded after a given timestamp
+      // or with an id greater than a given one have their webp and avif versions
+      const timestamp = Number.parseInt(image.filename.split('_')[0], 10);
+      if (!config.urls.modernThumbnailsTimestamp || timestamp < config.urls.modernThumbnailsTimestamp) {
+        return;
+      }
+      return backendFilename.substring(0, backendFilename.length - 3) + format;
+    }
   } else {
     backendFilename = image.filename;
   }
 
   return `${config.urls.media}/${backendFilename}`;
-};
-
-export default {
-  /* 200*200 px images */
-  getSquared(image) {
-    return getUrl(image, 'SI');
-  },
-
-  // max 400*400
-  getMedium(image) {
-    return getUrl(image, 'MI');
-  },
-
-  //
-  getBig(image) {
-    return getUrl(image, 'BI');
-  },
-
-  /* Original size */
-  get(image) {
-    return getUrl(image);
-  },
 };

--- a/src/views/document/ImageView.vue
+++ b/src/views/document/ImageView.vue
@@ -42,7 +42,7 @@
       <div class="column is-9">
         <div class="box is-paddingless">
           <a :href="getOriginalImageUrl(document)">
-            <img class="main-image" :src="getBigImageUrl(document)" />
+            <thumbnail class="main-image" :img="document" size="BI" />
           </a>
         </div>
 
@@ -66,7 +66,7 @@
 import MaskedDocumentVersionInfo from './utils/MaskedDocumentVersionInfo';
 import documentViewMixin from './utils/document-view-mixin';
 
-import imageUrls from '@/js/image-urls';
+import { getImageUrl } from '@/js/image-urls';
 
 export default {
   components: {
@@ -76,8 +76,7 @@ export default {
   mixins: [documentViewMixin],
 
   methods: {
-    getOriginalImageUrl: imageUrls.get,
-    getBigImageUrl: imageUrls.getBig,
+    getOriginalImageUrl: getImageUrl,
   },
 };
 </script>

--- a/src/views/document/utils/document-view-mixin.js
+++ b/src/views/document/utils/document-view-mixin.js
@@ -278,7 +278,7 @@ export default {
       return {
         '@context': 'https://schema.org',
         '@type': 'ImageObject',
-        contentUrl: imageUrls.get(this.document),
+        contentUrl: getImageUrl(this.document),
         license,
         acquireLicensePage: 'https://www.camptocamp.org/articles/106728',
       };

--- a/src/views/document/utils/document-view-mixin.js
+++ b/src/views/document/utils/document-view-mixin.js
@@ -16,7 +16,7 @@ import ProfilesLinks from './field-viewers/ProfilesLinks';
 import c2c from '@/js/apis/c2c';
 import constants from '@/js/constants';
 import cooker from '@/js/cooker';
-import imageUrls from '@/js/image-urls';
+import { getImageUrl } from '@/js/image-urls';
 import isEditableMixin from '@/js/is-editable-mixin';
 import utils from '@/js/utils';
 import viewModeMixin from '@/js/view-mode-mixin';
@@ -295,7 +295,7 @@ export default {
         const image = this.document.associations.images[0];
         inner = {
           ...inner,
-          image: [imageUrls.getBig(image)],
+          image: [getImageUrl(image, 'BI')],
         };
       }
       return inner;
@@ -320,7 +320,7 @@ export default {
       }
       if (this.document.associations?.images?.length) {
         const image = this.document.associations.images[0];
-        meta = [...meta, { p: 'og:image', c: imageUrls.getBig(image), id: 'meta-og-image' }];
+        meta = [...meta, { p: 'og:image', c: getImageUrl(image, 'BI'), id: 'meta-og-image' }];
       }
       return meta;
     },

--- a/src/views/documents/utils/ImageCards.vue
+++ b/src/views/documents/utils/ImageCards.vue
@@ -7,24 +7,18 @@
       :title="$documentUtils.getDocumentTitle(document)"
       class="card-image"
     >
-      <img :src="getMediumImageUrl(document)" height="250" loading="lazy" />
+      <thumbnail :img="document" size="MI" height="250" loading="lazy" />
     </document-link>
   </div>
 </template>
 
 <script>
-import imageUrls from '@/js/image-urls';
-
 export default {
   props: {
     documents: {
       type: Object,
       required: true,
     },
-  },
-
-  methods: {
-    getMediumImageUrl: imageUrls.getMedium,
   },
 };
 </script>

--- a/src/views/portals/SophiePictureContestView.vue
+++ b/src/views/portals/SophiePictureContestView.vue
@@ -23,8 +23,9 @@
           </div>
           <div class="has-text-centered">
             <document-link :document="{ ...winner.image, type: 'i' }">
-              <img
-                :src="getImageUrl(winner.image)"
+              <thumbnail
+                :img="getImageUrl(winner.image)"
+                size="MI"
                 :alt="
                   $documentUtils.getDocumentTitle({
                     ...winner.image,
@@ -65,7 +66,7 @@
           :title="$documentUtils.getDocumentTitle(image)"
           class="card-image"
         >
-          <img :src="getImageUrl(image)" loading="lazy" :alt="$documentUtils.getDocumentTitle(image)" />
+          <img :img="image" size="MI" loading="lazy" :alt="$documentUtils.getDocumentTitle(image)" />
         </document-link>
       </div>
       <loading-notification v-else :promise="promise" />
@@ -75,7 +76,6 @@
 
 <script>
 import c2c from '@/js/apis/c2c';
-import imageUrls from '@/js/image-urls';
 
 let associations = [];
 
@@ -521,8 +521,6 @@ export default {
         this.images = contributions.map((c) => c.image);
       }
     },
-
-    getImageUrl: imageUrls.getMedium,
   },
 };
 </script>

--- a/src/views/portals/SophiePictureContestView.vue
+++ b/src/views/portals/SophiePictureContestView.vue
@@ -66,7 +66,7 @@
           :title="$documentUtils.getDocumentTitle(image)"
           class="card-image"
         >
-          <img :img="image" size="MI" loading="lazy" :alt="$documentUtils.getDocumentTitle(image)" />
+          <thumbnail :img="image" size="MI" loading="lazy" :alt="$documentUtils.getDocumentTitle(image)" />
         </document-link>
       </div>
       <loading-notification v-else :promise="promise" />

--- a/src/views/wiki/DiffView.vue
+++ b/src/views/wiki/DiffView.vue
@@ -82,10 +82,10 @@
         <div v-if="filenameHasChanged">
           <div class="columns">
             <div class="column">
-              <img :src="getImageUrl(oldVersion.document)" class="is-pulled-right" />
+              <thumbnail :img="oldVersion.document" size="MI" class="is-pulled-right" />
             </div>
             <div class="column">
-              <img :src="getImageUrl(newVersion.document)" />
+              <thumbnail :img="newVersion.document" size="MI" />
             </div>
           </div>
         </div>
@@ -180,7 +180,6 @@ import { diffMatchPatch } from './utils/diff_match_patch_uncompressed';
 
 import c2c from '@/js/apis/c2c';
 import constants from '@/js/constants';
-import imageUrls from '@/js/image-urls';
 import noRobotsMixin from '@/js/no-robots-mixin';
 
 const hasChanged = function (oldVal, newVal) {
@@ -433,8 +432,6 @@ export default {
   },
 
   methods: {
-    getImageUrl: imageUrls.getMedium,
-
     loadVersions() {
       this.loadVersion(this.$route.params.versionFrom, 'oldVersion');
       this.loadVersion(this.$route.params.versionTo, 'newVersion');

--- a/src/views/wiki/edition/ImageEditionView.vue
+++ b/src/views/wiki/edition/ImageEditionView.vue
@@ -32,7 +32,7 @@
               </label>
             </div>
           </div>
-          <img v-if="newVersionSource" src="newVersionSource" />
+          <img v-if="newVersionSource" :src="newVersionSource" />
           <thumbnail v-else :img="document" size="MI" />
         </div>
       </div>

--- a/src/views/wiki/edition/ImageEditionView.vue
+++ b/src/views/wiki/edition/ImageEditionView.vue
@@ -32,7 +32,8 @@
               </label>
             </div>
           </div>
-          <img :src="newVersionSource ? newVersionSource : getImageUrl(document)" />
+          <img v-if="newVersionSource" src="newVersionSource" />
+          <thumbnail v-else :img="document" size="MI" />
         </div>
       </div>
     </form-section>
@@ -81,7 +82,6 @@
 <script>
 import documentEditionViewMixin from './utils/document-edition-view-mixin';
 
-import imageUrls from '@/js/image-urls';
 import uploadFile from '@/js/upload-file';
 
 export default {
@@ -105,8 +105,6 @@ export default {
   },
 
   methods: {
-    getImageUrl: imageUrls.getMedium,
-
     beforeSave() {
       this.$refs.qualityField.beforeSave();
     },

--- a/vue.config.js
+++ b/vue.config.js
@@ -99,6 +99,8 @@ const config = {
       tracking: 'https://tracking.demov6.camptocamp.org',
       forum: 'https://forum.demov6.camptocamp.org',
       recaptchaKey: '6LfWUwoUAAAAAAxud1qqok6wOJJlCUsYXxHizRhc',
+      modernThumbnailsTimestamp: 0,
+      modernThumbnailsId: 0,
     },
     prod: {
       name: 'prod',
@@ -108,11 +110,13 @@ const config = {
       tracking: 'https://tracking.camptocamp.org',
       forum: 'https://forum.camptocamp.org',
       recaptchaKey: '6Lc9Cw4UAAAAAIKnlar0AOsGX_P5S-bk9u8viuo2',
+      modernThumbnailsTimestamp: 0,
+      modernThumbnailsId: 0,
     },
   },
 };
 
-config.urls = config.urlsConfigurations.prod; // default : prod
+config.urls = config.urlsConfigurations.prod; // default: prod
 
 const bundleAnalyzerConfig = {
   analyzerMode: 'disabled',
@@ -120,13 +124,15 @@ const bundleAnalyzerConfig = {
 };
 
 if (process.env.BUILD_ENV === 'local' || process.env.BUILD_ENV === undefined) {
-  // add an url conf for local API devloppers :
+  // add an url conf for local API developers:
   config.urlsConfigurations.localhost = {
     name: 'localhost',
     api: 'http://localhost:6543',
     media: 'https://sos-ch-dk-2.exo.io/c2corg-demov6-active',
     imageBackend: 'https://images.demov6.camptocamp.org',
     forum: 'https://forum.demov6.camptocamp.org',
+    modernThumbnailsTimestamp: 0,
+    modernThumbnailsId: 0,
   };
 
   config.ignApiKey = 'hzuh5yjuto8lqbqs2njo0che'; // Key valid for localhost (Expires 08/11/2019)


### PR DESCRIPTION
The goal is to replace \<img> by \<picture> each time we refer to a thumbnail (SI, MI, BI) of a c2c image, and propose webp and avif format to the browser.

A timestamp and start id are defined in config, so that we don't try to get avif or webp if they are not generated.
Ultimately we should have a script generating all missing avif and webp thumbnails and get rid of this limitation.

There are a few places to be checked (currently slideshows are often broken):

- [x] AssociationImageLink
- [x] Gallery - often a display / slide issue until we resize a bit the window with chrome ??
- [x] Markdown
- [x] ImageViewer : error when zooming in / out
- [x] ImageCards
- [x] SophiePictureContestView
- [x] DiffView
- [x] ImageEditionView

(All of the above only tested on chrome desktop and firefox desktop at the moment)