### PR TITLE
fix(markdown): add style to markdown content for better images placement

### DIFF
--- a/src/components/generics/Markdown.vue
+++ b/src/components/generics/Markdown.vue
@@ -166,10 +166,17 @@ export default {
 <style lang="scss">
 // Not scoped syle, because CSS selector are not explicitly present in template
 .markdown-content {
+
+  overflow: auto;
+
   &:not(:last-child) {
     margin-bottom: 1.5rem;
   }
 
+  h3, h4, h5 {
+    display: inline-block;
+    width: 100%;
+  }
   h3 {
     font-size: 1.5rem !important;
     margin-bottom: 0.5em !important;


### PR DESCRIPTION
fix https://github.com/c2corg/c2c_ui/issues/3091

* style of titles changed from block to inline-block + width 100% to avoid overlapping with images
* style of markdown-content changed to overflow : auto to prevent images to overflow the markdown container