### PR TITLE
Allow to open map feature in new tab/window

### DIFF
--- a/src/components/map/OlMap.vue
+++ b/src/components/map/OlMap.vue
@@ -1005,10 +1005,23 @@ export default {
       if (feature) {
         const document = feature.get('document');
         if (document) {
-          this.$router.push({
-            name: this.$documentUtils.getDocumentType(document.type),
-            params: { id: document.document_id },
-          });
+          if (this.documents.length === 1 && document.document_id === this.documents[0].document_id) {
+            return;
+          }
+          if (event.originalEvent.ctrlKey) {
+            window.open(
+              this.$router.resolve({
+                name: this.$documentUtils.getDocumentType(document.type),
+                params: { id: document.document_id },
+              }),
+              '_blank'
+            );
+          } else {
+            this.$router.push({
+              name: this.$documentUtils.getDocumentType(document.type),
+              params: { id: document.document_id },
+            });
+          }
         } else if (feature.get('biodivData')) {
           this.biodivData = feature.get('biodivData');
           this.$refs.BiodivInformation.show();

--- a/src/components/map/OlMap.vue
+++ b/src/components/map/OlMap.vue
@@ -1,5 +1,4 @@
 <template>
-  <!-- TODO on route view, map in full screen has not a full height -->
   <div style="width: 100%; height: 100%">
     <div ref="map" style="width: 100%; height: 100%" @click="showLayerSwitcher = false" />
 
@@ -769,7 +768,7 @@ export default {
     },
 
     addDocumentFeature(document, source, style) {
-      if (!document || !document.geometry) {
+      if (!document?.geometry) {
         return;
       }
 


### PR DESCRIPTION
Using `CTRL` key, feature is opened in new tab/window (depending on browser configuration). User may need to accept popups opening first.


In the same time, do not open document if self (be it in another tab/window on in place)