### PR TITLE
feat: documents query bar position on mobile

### DIFF
--- a/src/views/documents/DocumentsView.vue
+++ b/src/views/documents/DocumentsView.vue
@@ -43,21 +43,22 @@
               :title="$gettext('Cards mode')"
             />
           </span>
-          <display-mode-switch
-            v-if="documentAreGeoLocalized"
-            class="header-item is-hidden-mobile"
-            list-mode="listMode"
-            :value="displayMode"
-            @input="setProperty('displayMode', arguments[0])"
-          />
-
-          <span class="header-item is-size-3 is-hidden-tablet">
-            <fa-icon
-              :icon="displayMode === 'map' ? 'th' : 'map-marked-alt'"
-              class="has-text-primary"
-              @click="setProperty('displayMode', displayMode === 'map' ? 'both' : 'map')"
+          <template v-if="documentAreGeoLocalized">
+            <display-mode-switch
+              class="header-item is-hidden-mobile"
+              list-mode="listMode"
+              :value="displayMode"
+              @input="setProperty('displayMode', arguments[0])"
             />
-          </span>
+
+            <span class="is-size-3 is-hidden-tablet">
+              <fa-icon
+                :icon="displayMode === 'map' ? 'th' : 'map-marked-alt'"
+                class="has-text-primary"
+                @click="setProperty('displayMode', displayMode === 'map' ? 'both' : 'map')"
+              />
+            </span>
+          </template>
         </span>
       </div>
 
@@ -323,6 +324,10 @@ $cards-gap: 0.25rem;
     padding-left: 0.5rem;
     padding-right: 0.5rem;
     padding-bottom: $mobile-section-padding;
+  }
+
+  .header-right {
+    line-height: 1em;
   }
 
   .map-container {

--- a/src/views/documents/utils/PageSelector.vue
+++ b/src/views/documents/utils/PageSelector.vue
@@ -19,25 +19,27 @@
     >
       <fa-icon icon="chevron-right" />
     </component>
-    <dropdown-button class="ml-1 mr-1" ref="limitSelector">
-      <span slot="button" class="button is-small">
-        <span>{{ queryLimit }}</span>
-        &nbsp;
-        <fa-icon icon="angle-down" aria-hidden="true" />
-      </span>
-      <component
-        v-for="l in [30, 50, 100]"
-        :key="l"
-        :is="'router-link'"
-        class="dropdown-item is-small"
-        :class="{ 'is-active': queryLimit === l }"
-        :to="pageQuery(offset, l)"
-        @click.native="hideOnclick"
-      >
-        <span>{{ l }}</span>
-      </component>
-    </dropdown-button>
-    <span v-translate translate-context="30 per page">per page</span>
+    <span class="limit-selector">
+      <dropdown-button class="ml-1 mr-1" ref="limitSelector">
+        <span slot="button" class="button is-small">
+          <span>{{ queryLimit }}</span>
+          &nbsp;
+          <fa-icon icon="angle-down" aria-hidden="true" />
+        </span>
+        <component
+          v-for="l in [30, 50, 100]"
+          :key="l"
+          :is="'router-link'"
+          class="dropdown-item is-small"
+          :class="{ 'is-active': queryLimit === l }"
+          :to="pageQuery(offset, l)"
+          @click.native="hideOnclick"
+        >
+          <span>{{ l }}</span>
+        </component>
+      </dropdown-button>
+      <span v-translate translate-context="30 per page">per page</span>
+    </span>
   </span>
 </template>
 
@@ -99,5 +101,10 @@ export default {
 <style scoped lang="scss">
 .pagination-link {
   height: 1.75em;
+}
+@media screen and (max-width: 340px) {
+  .limit-selector {
+    display: none;
+  }
 }
 </style>

--- a/src/views/documents/utils/QueryItems.vue
+++ b/src/views/documents/utils/QueryItems.vue
@@ -397,6 +397,14 @@ export default {
 .query-items-filters {
   margin-bottom: 0.5rem;
   font-size: 0;
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   > div {
     font-size: 1rem;


### PR DESCRIPTION
* fix display mode switcher position on mobile
* hide items per page selector on small widths
* query items bar will not span on several lines, use invisible horizontal scroll if needed

![image](https://user-images.githubusercontent.com/2234024/210059645-0c652a98-cdaf-4fc5-a685-873ff884b00d.png)
