### PR TITLE
chore: no more legacy build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  presets: ['@vue/cli-plugin-babel/preset'],
+  presets: [['@vue/cli-plugin-babel/preset', { targets: { esmodules: true }, polyfills: [] }]],
   /*
    * Looks like since we updated browserslist + caniuse database to support only recent browsers, we need to manually
    * include plugins.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "author": "Camptocamp community <dev@camptocamp.org>",
   "scripts": {
     "serve": "cross-env BUILD_ENV=local vue-cli-service serve",
-    "build": "cross-env BUILD_ENV=camptocamp vue-cli-service build --skip-plugins eslint",
+    "build": "cross-env BUILD_ENV=camptocamp vue-cli-service build --no-module --skip-plugins eslint",
     "lint": "prettier --write \"**/*.{ts,js,json,css,scss,less,md,html,vue}\" && npm run lint:style && vue-cli-service lint",
-    "build:github": "cross-env BUILD_ENV=github vue-cli-service build --skip-plugins eslint",
+    "build:github": "cross-env BUILD_ENV=github vue-cli-service build --no-module --skip-plugins eslint",
     "generate-icons": "node tools/generate-icons.js",
     "lint:no-fix": "prettier --check \"**/*.{ts,js,json,css,scss,less,md,html,vue}\" && npm run lint:style && vue-cli-service lint --no-fix",
     "lint:style": "stylelint \"src/**/*.{vue,scss}\"",


### PR DESCRIPTION
Our browser target all support modern javascript. This will sped up build time.