### PR TITLE
fix(yeti): performance improvements

### DIFF
--- a/src/components/yeti/map-layers/AreaLayer.vue
+++ b/src/components/yeti/map-layers/AreaLayer.vue
@@ -61,8 +61,7 @@ export default {
     });
 
     // layer for outer stroke of areas
-    this.areasStrokeLayer = new ol.layer.Vector({
-      renderMode: 'image',
+    this.areasStrokeLayer = new ol.layer.VectorImage({
       source: new ol.source.Vector(),
       style: [
         new ol.style.Style({
@@ -83,9 +82,8 @@ export default {
 
     // layer for clip
     // should set className, this forces ol to create another canvas
-    this.areasLayer = new ol.layer.Vector({
+    this.areasLayer = new ol.layer.VectorImage({
       className: Yetix.BLEND_MODES_CLASS_NAME,
-      renderMode: 'image',
       source: new ol.source.Vector(),
       style: new ol.style.Style({
         fill: new ol.style.Fill({

--- a/src/components/yeti/map-layers/AvalancheBulletinsLayer.vue
+++ b/src/components/yeti/map-layers/AvalancheBulletinsLayer.vue
@@ -241,7 +241,7 @@ let bulletinsStyle = (mapZoom, danger) => {
   });
 };
 
-let mountainsLayer = new ol.layer.Vector({
+let mountainsLayer = new ol.layer.VectorImage({
   source: new ol.source.Vector(),
   style: mountainsStyle(),
 });

--- a/src/js/libs/ol.js
+++ b/src/js/libs/ol.js
@@ -13,6 +13,7 @@ import GroupLayer from 'ol/layer/Group';
 import ImageLayer from 'ol/layer/Image';
 import TileLayer from 'ol/layer/Tile';
 import VectorLayer from 'ol/layer/Vector';
+import VectorImageLayer from 'ol/layer/VectorImage';
 import { get as getProjection, toLonLat, transformExtent, transform as transformProjection } from 'ol/proj';
 import BingMaps from 'ol/source/BingMaps';
 import ImageStatic from 'ol/source/ImageStatic';
@@ -76,6 +77,7 @@ export default {
 
   layer: {
     Vector: VectorLayer,
+    VectorImage: VectorImageLayer,
     Tile: TileLayer,
     Image: ImageLayer,
     Group: GroupLayer,


### PR DESCRIPTION
Hello,
This PR replaces `ol.layer.Vector` with `VectorImage` for some layers to improve perf on pan/zoom when avalanche bulletins are shown.