### PR TITLE
fix: create public directory before copying files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:lts-alpine as build-stage
 WORKDIR /
 COPY package*.json ./
 COPY .snyk ./
+RUN mkdir -p public
 RUN npm install
 COPY . .
 RUN npm run build


### PR DESCRIPTION
so that prepare task runs successfully