### PR TITLE
feat: add license information when printing

### DIFF
--- a/src/assets/sass/helpers.scss
+++ b/src/assets/sass/helpers.scss
@@ -48,6 +48,12 @@
   border-radius: $radius;
 }
 
+@media not print {
+  .print-only {
+    display: none !important;
+  }
+}
+
 @media print {
   /* print styles go here */
 
@@ -83,5 +89,17 @@
 
   .is-12-print {
     width: 100% !important;
+  }
+
+  @media print {
+    .print-no-columns {
+      display: block !important;
+
+      @each $size in 1, 2, 3, 4, 5, 6, 7, 9, 10, 11 {
+        .is-#{$size} {
+          width: 100%;
+        }
+      }
+    }
   }
 }

--- a/src/js/vue-plugins/document-utils.js
+++ b/src/js/vue-plugins/document-utils.js
@@ -50,6 +50,41 @@ export default function install(Vue) {
         return locale.title ?? '';
       },
 
+      getDocumentLicense(document) {
+        const documentType = this.$documentUtils.getDocumentType(document.type);
+        if (['route', 'waypoint', 'area', 'book'].includes(documentType)) {
+          return 'by-sa';
+        }
+
+        if (['outing', 'profile', 'xreport'].includes(documentType)) {
+          return 'by-nc-nd';
+        }
+
+        if (documentType === 'article') {
+          if (document.article_type === 'collab') {
+            return 'by-sa';
+          } else if (document.article_type === 'personal') {
+            return 'by-nc-nd';
+          } else {
+            throw new Error(`Unexpected article_type : ${document.article_type}`);
+          }
+        }
+
+        if (documentType === 'image') {
+          if (document.image_type === 'collaborative') {
+            return 'by-sa';
+          } else if (document.image_type === 'personal') {
+            return 'by-nc-nd';
+          } else if (document.image_type === 'copyright') {
+            return 'copyright';
+          } else {
+            throw new Error(`Unexpected image_type : ${document.image_type}`);
+          }
+        }
+
+        throw new Error(`Unexpected document_type: ${documentType}`);
+      },
+
       getLocaleStupid(document, lang) {
         if (!document.locales) {
           return null;

--- a/src/views/document/AreaView.vue
+++ b/src/views/document/AreaView.vue
@@ -7,7 +7,7 @@
       :document-type="documentType"
     ></masked-document-version-info>
     <document-view-header v-if="document" :document="document" :version="version" />
-    <div v-if="document" class="columns">
+    <div v-if="document" class="columns print-no-columns">
       <div class="column is-3">
         <div class="box">
           <field-view :document="document" :field="fields.area_type" />
@@ -23,7 +23,7 @@
           <div style="clear: both" />
         </div>
 
-        <div class="box">
+        <div class="box no-print">
           <div class="level is-mobile">
             <div
               class="level-item has-text-centered"
@@ -46,6 +46,7 @@
 
         <comments-box :document="document" />
       </div>
+      <document-print-license :document="document" />
     </div>
   </div>
 </template>

--- a/src/views/document/ArticleView.vue
+++ b/src/views/document/ArticleView.vue
@@ -37,6 +37,7 @@
         <tool-box :document="document" v-if="$screen.isMobile" />
         <comments-box v-if="!isDraftView" :document="document" />
       </div>
+      <document-print-license :document="document" />
     </div>
   </div>
 </template>

--- a/src/views/document/BookView.vue
+++ b/src/views/document/BookView.vue
@@ -41,6 +41,7 @@
 
         <comments-box :document="document" />
       </div>
+      <document-print-license :document="document" />
     </div>
   </div>
 </template>

--- a/src/views/document/ImageView.vue
+++ b/src/views/document/ImageView.vue
@@ -7,7 +7,7 @@
       :document-type="documentType"
     ></masked-document-version-info>
     <document-view-header v-if="document" :document="document" :version="version" />
-    <div v-if="document" class="columns">
+    <div v-if="document" class="columns print-no-columns">
       <div class="column is-3">
         <div class="box">
           <activities-field v-if="document.activities && document.activities.length" :document="document" />
@@ -58,6 +58,7 @@
         <tool-box :document="document" v-if="$screen.isMobile" />
         <comments-box :document="document" />
       </div>
+      <document-print-license :document="document" />
     </div>
   </div>
 </template>

--- a/src/views/document/OutingView.vue
+++ b/src/views/document/OutingView.vue
@@ -18,7 +18,7 @@
 
       <div class="column is-9 is-12-print">
         <div class="box">
-          <div v-for="route of document.associations.routes" :key="route.document_id">
+          <div class="no-print" v-for="route of document.associations.routes" :key="route.document_id">
             <pretty-route-link :route="route" hide-area hide-orientation />
           </div>
 
@@ -108,6 +108,7 @@
 
         <comments-box :document="document" />
       </div>
+      <document-print-license :document="document" />
     </div>
   </div>
 </template>

--- a/src/views/document/RouteView.vue
+++ b/src/views/document/RouteView.vue
@@ -131,6 +131,7 @@
 
         <comments-box :document="document" />
       </div>
+      <document-print-license :document="document" />
     </div>
   </div>
 </template>
@@ -139,6 +140,7 @@
 import LowDocumentQualityBanner from './utils/LowDocumentQualityBanner';
 import MaskedDocumentVersionInfo from './utils/MaskedDocumentVersionInfo';
 import documentViewMixin from './utils/document-view-mixin';
+
 const historyWorthActivities = [
   'snow_ice_mixed',
   'mountain_climbing',

--- a/src/views/document/WaypointView.vue
+++ b/src/views/document/WaypointView.vue
@@ -134,6 +134,7 @@
         <images-box v-if="!isDraftView" :document="document" />
         <tool-box :document="document" v-if="$screen.isMobile" />
         <comments-box v-if="!isDraftView" :document="document" />
+        <document-print-license :document="document" />
       </div>
     </div>
   </div>

--- a/src/views/document/XreportView.vue
+++ b/src/views/document/XreportView.vue
@@ -68,6 +68,7 @@
 
         <comments-box :document="document" />
       </div>
+      <document-print-license :document="document" />
     </div>
   </div>
 </template>

--- a/src/views/document/utils/DocumentPrintLicense.vue
+++ b/src/views/document/utils/DocumentPrintLicense.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="print-only is-flex is-justify-content-space-between">
+    <div class="m-2 has-text-grey is-italic">
+      <p>{{ license }}</p>
+      <p v-translate v-if="documentType !== 'image'">
+        Images are under license specified in the original document of each image
+      </p>
+      <!-- Until we can reference the document version -->
+      <p class="mt-2"><span v-translate>Printed on</span> {{ $dateUtils.toLocalizedString(new Date(), 'LLL') }}</p>
+    </div>
+    <img loading="lazy" :src="qrcode" />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    document: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  computed: {
+    documentType() {
+      return this.$documentUtils.getDocumentType(this.document.type);
+    },
+
+    qrcode() {
+      const shortURL = encodeURIComponent(location.href.substring(0, location.href.lastIndexOf('/')));
+      return `https://chart.googleapis.com/chart?chs=90x90&cht=qr&chl=${shortURL}&choe=UTF-8&chld=M|1`;
+    },
+
+    license() {
+      // translations already defined in LicenseBox.vue
+      let license;
+      switch (this.$documentUtils.getDocumentLicense(this.document)) {
+        case 'by-sa':
+          license = 'This content is licensed under Creative Commons BY-SA 3.0';
+          break;
+        case 'by-nc-nd':
+          license = 'This content is licensed under Creative Commons BY-NC-ND 3.0';
+          break;
+        case 'copyright':
+        default:
+          license = 'This book cover is the property of its editor and/or author';
+      }
+      return this.$gettext(license);
+    },
+  },
+};
+</script>

--- a/src/views/document/utils/boxes/LicenseBox.vue
+++ b/src/views/document/utils/boxes/LicenseBox.vue
@@ -28,7 +28,7 @@
       </span>
       3.0
       <br />
-      <span v-translate> This content is licensed under Creative Commons BY-SA 3.0 </span>
+      <span v-translate>This content is licensed under Creative Commons BY-SA 3.0</span>
     </a>
     <a
       v-else-if="license == 'by-nc-nd'"
@@ -59,7 +59,7 @@
       </span>
       3.0
       <br />
-      <span v-translate> This content is licensed under Creative Commons BY-NC-ND 3.0 </span>
+      <span v-translate>This content is licensed under Creative Commons BY-NC-ND 3.0</span>
     </a>
     <span
       v-else-if="license == 'copyright'"
@@ -70,7 +70,7 @@
       "
     >
       <fa-icon icon="ban" />
-      <span v-translate> This book cover is the property of its editor and/or author </span>
+      <span v-translate>This book cover is the property of its editor and/or author</span>
     </span>
   </div>
 </template>
@@ -86,37 +86,7 @@ export default {
     // collaborative means CC-By-Sa
 
     license() {
-      if (['route', 'waypoint', 'area', 'book'].includes(this.documentType)) {
-        return 'by-sa';
-      }
-
-      if (['outing', 'profile', 'xreport'].includes(this.documentType)) {
-        return 'by-nc-nd';
-      }
-
-      if (this.documentType === 'article') {
-        if (this.document.article_type === 'collab') {
-          return 'by-sa';
-        } else if (this.document.article_type === 'personal') {
-          return 'by-nc-nd';
-        } else {
-          throw new Error(`Unexpected article_type : ${this.document.article_type}`);
-        }
-      }
-
-      if (this.documentType === 'image') {
-        if (this.document.image_type === 'collaborative') {
-          return 'by-sa';
-        } else if (this.document.image_type === 'personal') {
-          return 'by-nc-nd';
-        } else if (this.document.image_type === 'copyright') {
-          return 'copyright';
-        } else {
-          throw new Error(`Unexpected image_type : ${this.document.image_type}`);
-        }
-      }
-
-      throw new Error(`Unexpected document_type: ${this.documentType}`);
+      return this.$documentUtils.getDocumentLicense(this.document);
     },
   },
 };

--- a/src/views/document/utils/document-view-mixin.js
+++ b/src/views/document/utils/document-view-mixin.js
@@ -1,3 +1,4 @@
+import DocumentPrintLicense from './DocumentPrintLicense';
 import DocumentViewHeader from './DocumentViewHeader';
 import CommentsBox from './boxes/CommentsBox';
 import ImagesBox from './boxes/ImagesBox';
@@ -26,6 +27,7 @@ export default {
     DocumentViewHeader,
 
     CommentsBox,
+    DocumentPrintLicense,
     DoubleNumericField,
     FieldView,
     LabelValue,


### PR DESCRIPTION
fixes #2484 

Until we have a docuent version from the API, print the date of the document generation.

Also enhance some document type print rendering in the meantime.