### PR TITLE
Bug: Soft-mobility marker doesn't have se same structure as other markers

### DIFF
--- a/src/components/generics/markers/MarkerSoftMobility.vue
+++ b/src/components/generics/markers/MarkerSoftMobility.vue
@@ -1,3 +1,5 @@
 <template>
-  <fa-icon icon="bus" :title="$gettext('Soft mobility outing')"></fa-icon>
+  <span :title="$gettext('Soft mobility outing')">
+    <fa-icon icon="bus"></fa-icon>
+  </span>
 </template>


### PR DESCRIPTION
So we can't tag it the same way as other markers with css and it doesn't have the same behaviour (padding, alignment...)