### PR TITLE
bug: Dashboard view - Route documents' quality

### DIFF
--- a/src/views/portals/utils/DashboardRouteLink.vue
+++ b/src/views/portals/utils/DashboardRouteLink.vue
@@ -11,6 +11,7 @@
       {{ route.height_diff_difficulties }}&nbsp;m</span
     >
     <document-rating :document="filteredDocument" />
+    <marker-quality :quality="route.quality" />
   </dashboard-link>
 </template>
 

--- a/src/views/portals/utils/DashboardRoutesList.vue
+++ b/src/views/portals/utils/DashboardRoutesList.vue
@@ -43,8 +43,10 @@ export default {
     },
   },
 
-  created() {
-    this.routesPromise = c2c.route.getAll({ limit: 5 });
+  created(query = {}) {
+    query.limit = 15;
+    query.qa = 'draft,great';
+    this.routesPromise = c2c.route.getAll(query);
   },
 };
 </script>


### PR DESCRIPTION
On home, when dashboard is activated, add quality icon to routes links and do not display empty routes.