### PR TITLE
feat: 3516-add-preference-label-on-mobile

### DIFF
--- a/src/views/portals/HomeView.vue
+++ b/src/views/portals/HomeView.vue
@@ -30,7 +30,7 @@
               <span :class="{ 'is-active': feed }" @click="toggleProperty('feed')" v-translate>Activity feed</span>
             </label>
           </span>
-          <span class="is-pulled-right">
+          <span class="preference-switch">
             <span v-if="$user.isLogged">
               <input
                 id="c2c-personal-feed"
@@ -43,7 +43,7 @@
                 for="c2c-personal-feed"
                 :title="isPersonal ? $gettext('Personal feed on') : $gettext('Personal feed off')"
               >
-                <span class="is-hidden-mobile" v-translate>Load my preferences</span>
+                <span v-translate>Load my preferences</span>
               </label>
             </span>
             <router-link to="preferences" class="has-text-normal" :title="$gettext('My preferences')">
@@ -141,11 +141,35 @@ export default {
       padding-right: 0;
     }
   }
+
+  .field {
+    flex-direction: column;
+  }
+
+  .preference-switch {
+    margin-top: 0.3rem;
+    margin-left: 0.3rem;
+    display: flex;
+  }
+
+  .preference-switch > span {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  .preference-switch > span > * {
+    margin-right: 0.3rem;
+  }
 }
 
 @media screen and (min-width: $tablet) {
   .feed-view {
     margin-top: $size-3;
+  }
+
+  .field {
+    justify-content: space-between;
+    align-items: baseline;
   }
 }
 
@@ -189,5 +213,9 @@ export default {
   padding: 3px 10px;
   text-align: center;
   z-index: 100;
+}
+
+.field {
+  display: flex;
 }
 </style>


### PR DESCRIPTION
closes #3516  

Le toggleswitch devient une checkbox pour la version mobile, je ne sais pas si c'est normal, peut-être pour une question de lisibilité ? En tous cas je peux modifier au besoin.

Aperçu : 
<img width="324" alt="image" src="https://github.com/c2corg/c2c_ui/assets/47505847/056da593-6d24-4779-bc83-9517ad736d67">

