### PR TITLE
feat: move-help-and-yeti-links

### DIFF
--- a/src/views/Navigation.vue
+++ b/src/views/Navigation.vue
@@ -19,6 +19,14 @@
     </router-link>
 
     <div class="navigation-end">
+      <router-link
+        :to="{ name: 'article', params: { id: 106732 } }"
+        class="navigation-item has-text-centered"
+        :class="{ 'is-hidden-mobile': !hideSearchInput }"
+      >
+        <icon-help fixed-width />
+        <span class="is-hidden-mobile"> {{ $gettext('help') | uppercaseFirstLetter }} </span>
+      </router-link>
       <div ref="searchInputContainer">
         <input-document
           ref="searchInput"
@@ -147,9 +155,11 @@
 </template>
 
 <script>
+import IconHelp from '@/components/generics/icons/IconHelp';
 import config from '@/js/config';
 
 export default {
+  components: { IconHelp },
   data() {
     return {
       searchText: '',

--- a/src/views/SideMenu.vue
+++ b/src/views/SideMenu.vue
@@ -53,10 +53,10 @@
         <span class="menu-item-text"> {{ $gettext('articles') | uppercaseFirstLetter }} </span>
       </span>
     </router-link>
-    <router-link :to="{ name: 'article', params: { id: 106732 } }" v-if="isTall">
-      <span class="menu-item is-ellipsed">
-        <icon-help fixed-width />
-        <span class="menu-item-text"> {{ $gettext('Help') | uppercaseFirstLetter }} </span>
+    <router-link :to="{ name: 'yeti' }" v-if="isTall">
+      <span class="menu-item is-ellipsed" :class="{ 'router-link-active': ['yeti'].includes($route.name) }">
+        <icon-yeti fixed-width />
+        <span class="menu-item-text"> {{ $gettext('yeti') | uppercaseFirstLetter }} </span>
       </span>
     </router-link>
 
@@ -105,8 +105,10 @@
 <script>
 import Advertisement from './Advertisement';
 
+import IconYeti from '@/components/generics/icons/IconYeti';
+
 export default {
-  components: { Advertisement },
+  components: { IconYeti, Advertisement },
 
   data() {
     return {


### PR DESCRIPTION
closes #3542 

Appears this way on dev : 
![image](https://github.com/c2corg/c2c_ui/assets/47505847/ca54e5b8-4527-4ad3-bdc5-0355babd5585)

Should I change the help link color ? By default it's blue and grey on hover like a classic link.