### PR TITLE
feat: Need help icon more explicite

### DIFF
--- a/src/components/generics/icons/IconHelp.vue
+++ b/src/components/generics/icons/IconHelp.vue
@@ -1,5 +1,5 @@
 <template>
-  <fa-icon icon="life-ring" :fixed-width="fixedWidth" />
+  <fa-icon icon="info-circle" :fixed-width="fixedWidth" />
 </template>
 
 <script>

--- a/src/js/vue-plugins/font-awesome-config.js
+++ b/src/js/vue-plugins/font-awesome-config.js
@@ -72,7 +72,6 @@ import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle';
 import { faItalic } from '@fortawesome/free-solid-svg-icons/faItalic';
 import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
 import { faLayerGroup } from '@fortawesome/free-solid-svg-icons/faLayerGroup';
-import { faLifeRing } from '@fortawesome/free-solid-svg-icons/faLifeRing';
 import { faLink } from '@fortawesome/free-solid-svg-icons/faLink';
 import { faList } from '@fortawesome/free-solid-svg-icons/faList';
 import { faListOl } from '@fortawesome/free-solid-svg-icons/faListOl';
@@ -303,7 +302,6 @@ export default function install(Vue) {
     faItalic,
     faKey,
     faLayerGroup,
-    faLifeRing,
     faLink,
     faList,
     faListOl,


### PR DESCRIPTION
The life-ring icon is not so user friendly.
Should use the info-circle icon as for tooltip's indication.

Discussed within the board