### PR TITLE
feat: Arrows to navigate search results while in a document

### DIFF
--- a/src/components/generics/links/DocumentLink.vue
+++ b/src/components/generics/links/DocumentLink.vue
@@ -1,6 +1,6 @@
 <template>
   <router-link
-    :to="{ name: documentType, params: { id: document.document_id, lang: lang } }"
+    :to="{ name: documentType, params: { id: document.document_id, lang: lang }, query: document.search_query }"
     :target="target"
     :title="$documentUtils.getDocumentTitle(document, $route.params.lang)"
   >

--- a/src/js/add-search-query.js
+++ b/src/js/add-search-query.js
@@ -1,0 +1,19 @@
+/*
+ * Small helper function to associate queries to a list of documents
+ *
+ * The documents are assumed to be the result of the query. The query associated
+ * to a document is the original query, but limited to 10 documents before, and
+ * 10 documents after.
+ */
+
+export const add_search_queries = function (query, documents) {
+  let add_query = (document, i) => {
+    let offset = query.offset ? query.offset : '0';
+    let index = parseInt(offset) + i; // index in the whole list of search results
+    let search_query = Object.assign({}, query);
+    search_query.offset = Math.max(0, index - 10); // We take 10 results before index
+    search_query.limit = index + 1 + 10 - search_query.offset; // And 10 results after index
+    document.search_query = search_query;
+  };
+  if (documents !== null) documents.forEach(add_query);
+};

--- a/src/views/document/AreaView.vue
+++ b/src/views/document/AreaView.vue
@@ -6,7 +6,13 @@
       :version="version"
       :document-type="documentType"
     ></masked-document-version-info>
-    <document-view-header v-if="document" :document="document" :version="version" />
+    <document-view-header
+      v-if="document"
+      :previous-document="previousDocument"
+      :next-document="nextDocument"
+      :document="document"
+      :version="version"
+    />
     <div v-if="document" class="columns print-no-columns">
       <div class="column is-3">
         <div class="box">

--- a/src/views/document/BookView.vue
+++ b/src/views/document/BookView.vue
@@ -6,7 +6,13 @@
       :version="version"
       :document-type="documentType"
     ></masked-document-version-info>
-    <document-view-header v-if="document" :document="document" :version="version" />
+    <document-view-header
+      v-if="document"
+      :previous-document="previousDocument"
+      :next-document="nextDocument"
+      :document="document"
+      :version="version"
+    />
     <div v-if="document" class="columns is-block-print">
       <div class="column is-3">
         <div class="box">
@@ -40,6 +46,7 @@
         <tool-box :document="document" v-if="$screen.isMobile" />
 
         <comments-box :document="document" />
+        <search-navigation-box document-type="book" :documents="search.documents" :index="index" />
       </div>
       <document-print-license :document="document" />
     </div>

--- a/src/views/document/ImageView.vue
+++ b/src/views/document/ImageView.vue
@@ -6,7 +6,13 @@
       :version="version"
       :document-type="documentType"
     ></masked-document-version-info>
-    <document-view-header v-if="document" :document="document" :version="version" />
+    <document-view-header
+      v-if="document"
+      :previous-document="previousDocument"
+      :next-document="nextDocument"
+      :document="document"
+      :version="version"
+    />
     <div v-if="document" class="columns print-no-columns">
       <div class="column is-3">
         <div class="box">

--- a/src/views/document/OutingView.vue
+++ b/src/views/document/OutingView.vue
@@ -6,7 +6,13 @@
       :version="version"
       :document-type="documentType"
     ></masked-document-version-info>
-    <document-view-header v-if="document" :document="document" :version="version" />
+    <document-view-header
+      v-if="document"
+      :previous-document="previousDocument"
+      :next-document="nextDocument"
+      :document="document"
+      :version="version"
+    />
 
     <images-box v-if="document" :document="document" />
 
@@ -107,6 +113,7 @@
         <tool-box :document="document" v-if="$screen.isMobile" />
 
         <comments-box :document="document" />
+        <search-navigation-box document-type="outing" :documents="search.documents" :index="index" />
       </div>
       <document-print-license :document="document" />
     </div>

--- a/src/views/document/RouteView.vue
+++ b/src/views/document/RouteView.vue
@@ -6,7 +6,13 @@
       :version="version"
       :document-type="documentType"
     ></masked-document-version-info>
-    <document-view-header v-if="document" :document="document" :version="version" />
+    <document-view-header
+      v-if="document"
+      :previous-document="previousDocument"
+      :next-document="nextDocument"
+      :document="document"
+      :version="version"
+    />
     <div v-if="document" class="columns is-block-print">
       <div class="column is-3 no-print">
         <map-box :document="document" @has-protection-area="hasProtectionArea = true" />
@@ -126,6 +132,8 @@
         <images-box :document="document" />
 
         <recent-outings-box :document="document" />
+
+        <search-navigation-box document-type="route" :documents="search.documents" :index="index" />
 
         <tool-box :document="document" v-if="$screen.isMobile" />
 

--- a/src/views/document/WaypointView.vue
+++ b/src/views/document/WaypointView.vue
@@ -6,7 +6,13 @@
       :version="version"
       :document-type="documentType"
     ></masked-document-version-info>
-    <document-view-header v-if="document" :document="document" :version="version">
+    <document-view-header
+      v-if="document"
+      :previous-document="previousDocument"
+      :next-document="nextDocument"
+      :document="document"
+      :version="version"
+    >
       <icon-waypoint-type
         v-if="document && document.waypoint_type"
         slot="icon-document"
@@ -134,6 +140,7 @@
         <images-box v-if="!isDraftView" :document="document" />
         <tool-box :document="document" v-if="$screen.isMobile" />
         <comments-box v-if="!isDraftView" :document="document" />
+        <search-navigation-box document-type="waypoint" :documents="search.documents" :index="index" />
         <document-print-license :document="document" />
       </div>
     </div>

--- a/src/views/document/utils/DocumentViewHeader.vue
+++ b/src/views/document/utils/DocumentViewHeader.vue
@@ -4,49 +4,55 @@
       <html-header v-if="!isDraftView && !isPrintingView" :title="title" />
 
       <document-version-banner :version="version" :document="document" />
+      <div class="columns">
+        <div class="column is-narrow" v-if="previousDocument">
+          <document-link :document="previousDocument" class="box">&lt;</document-link>
+        </div>
+        <div class="box column">
+          <span v-if="!isDraftView" class="is-pulled-right button-bar no-print">
+            <gotop-button v-if="isPrintingView" />
+            <follow-button v-if="!isPrintingView" :document="document" />
+            <tags-button v-if="!isPrintingView" :document="document" />
 
-      <div class="box">
-        <span v-if="!isDraftView" class="is-pulled-right button-bar no-print">
-          <gotop-button v-if="isPrintingView" />
-          <follow-button v-if="!isPrintingView" :document="document" />
-          <tags-button v-if="!isPrintingView" :document="document" />
+            <social-network-sharing v-if="documentType != 'profile' && isNormalView" />
 
-          <social-network-sharing v-if="documentType != 'profile' && isNormalView" />
+            <span
+              :title="$gettext('Add images')"
+              v-if="isEditable && documentType !== 'image'"
+              @click="$refs.imagesUploader.show()"
+            >
+              <fa-layers>
+                <fa-icon icon="image" />
+                <fa-icon icon="circle" :style="{ color: 'white' }" transform="shrink-5 right-5 up-6" />
+                <fa-icon icon="plus-circle" :style="{ color: 'green' }" transform="shrink-5 right-5 up-5" />
+              </fa-layers>
+            </span>
 
-          <span
-            :title="$gettext('Add images')"
-            v-if="isEditable && documentType !== 'image'"
-            @click="$refs.imagesUploader.show()"
-          >
-            <fa-layers>
-              <fa-icon icon="image" />
-              <fa-icon icon="circle" :style="{ color: 'white' }" transform="shrink-5 right-5 up-6" />
-              <fa-icon icon="plus-circle" :style="{ color: 'green' }" transform="shrink-5 right-5 up-5" />
-            </fa-layers>
+            <edit-link v-if="isEditable" :document="document" :lang="lang" :title="$gettext('Edit')">
+              <icon-edit />
+            </edit-link>
           </span>
+          <h1 class="column title">
+            <slot name="icon-document">
+              <icon-document :document-type="documentType" />
+            </slot>
+            <document-title :document="document" uppercase-first-letter />
 
-          <edit-link v-if="isEditable" :document="document" :lang="lang" :title="$gettext('Edit')">
-            <icon-edit />
-          </edit-link>
-        </span>
-        <h1 class="title is-1">
-          <slot name="icon-document">
-            <icon-document :document-type="documentType" />
-          </slot>
-          <document-title :document="document" uppercase-first-letter />
+            <!-- outing specific  -->
+            <span v-if="documentType == 'outing'" class="outing-date is-size-5">
+              {{ $documentUtils.getOutingDatesLocalized(document) | uppercaseFirstLetter }}
+            </span>
 
-          <!-- outing specific  -->
-          <span v-if="documentType == 'outing'" class="outing-date is-size-5">
-            {{ $documentUtils.getOutingDatesLocalized(document) | uppercaseFirstLetter }}
-          </span>
-
-          <!-- xreport specific  -->
-          <span v-else-if="documentType == 'xreport'" class="outing-date is-size-5">
-            {{ $dateUtils.toLocalizedString(document.date, 'll') | uppercaseFirstLetter }}
-          </span>
-        </h1>
+            <!-- xreport specific  -->
+            <span v-else-if="documentType == 'xreport'" class="outing-date is-size-5">
+              {{ $dateUtils.toLocalizedString(document.date, 'll') | uppercaseFirstLetter }}
+            </span>
+          </h1>
+        </div>
+        <div class="column is-narrow" v-if="nextDocument">
+          <document-link :document="nextDocument" class="box">&gt;</document-link>
+        </div>
       </div>
-
       <images-uploader ref="imagesUploader" :lang="lang" :parent-document="document" />
     </div>
   </div>
@@ -77,6 +83,14 @@ export default {
 
   props: {
     version: {
+      type: Object,
+      default: null,
+    },
+    previousDocument: {
+      type: Object,
+      default: null,
+    },
+    nextDocument: {
       type: Object,
       default: null,
     },

--- a/src/views/document/utils/boxes/RecentOutingsBox.vue
+++ b/src/views/document/utils/boxes/RecentOutingsBox.vue
@@ -28,6 +28,7 @@
 </template>
 
 <script>
+import { add_search_queries } from '@/js/add-search-query';
 import { requireDocumentProperty } from '@/js/properties-mixins';
 import viewModeMixin from '@/js/view-mode-mixin';
 
@@ -48,7 +49,8 @@ export default {
   computed: {
     outings() {
       let outings = this.document.associations.recent_outings?.documents || this.document.associations.outings;
-
+      let query = this.allOutingsQuery;
+      add_search_queries(query, outings);
       if (this.includeEmptyOutings) {
         return outings;
       } else {

--- a/src/views/document/utils/boxes/RoutesBox.vue
+++ b/src/views/document/utils/boxes/RoutesBox.vue
@@ -31,6 +31,7 @@
 </template>
 
 <script>
+import { add_search_queries } from '@/js/add-search-query';
 import { requireDocumentProperty } from '@/js/properties-mixins';
 
 export default {
@@ -55,9 +56,15 @@ export default {
     },
 
     source() {
-      let routes = (this.document.associations.routes || this.document.associations.all_routes.documents)
-        .map((route) => ({ ...route, title: this.$documentUtils.getDocumentTitle(route, this.$route.params.lang) }))
-        .sort((r1, r2) => r1.title.localeCompare(r2.title));
+      let routes = (this.document.associations.routes || this.document.associations.all_routes.documents).map(
+        (route) => ({
+          ...route,
+          title: this.$documentUtils.getDocumentTitle(route, this.$route.params.lang),
+          search_query: this.query,
+        })
+      );
+      add_search_queries(this.query, routes);
+      routes.sort((r1, r2) => r1.title.localeCompare(r2.title));
       if (this.document.type === 'w' && this.document?.waypoint_type !== 'climbing_outdoor') {
         // filter out crags for non climbing sites waypoints
         routes = routes.filter((route) => route?.climbing_outdoor_type !== 'single');

--- a/src/views/document/utils/boxes/SearchNavigationBox.vue
+++ b/src/views/document/utils/boxes/SearchNavigationBox.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="box no-print" v-if="isNormalView && documents.length !== 0">
+    <div class="title is-2">
+      <span v-translate>Associated Search</span>
+    </div>
+
+    <div v-for="(doc, i) of documents" :key="i">
+      <component v-if="i <= to && i >= from" :is="link" :class="current_index(i)" :[documentType]="doc" />
+    </div>
+
+    <div v-if="documents.length" class="has-text-centered add-section">
+      <router-link
+        :to="{ name: documentType + 's', query: allResultsQuery }"
+        class="button is-primary"
+        v-if="!hideSeeAllResultsButton && documents.length"
+      >
+        <span v-translate>Show search</span>
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script>
+import viewModeMixin from '@/js/view-mode-mixin';
+
+export default {
+  mixins: [viewModeMixin],
+
+  props: {
+    documentType: {
+      type: String,
+      default: '',
+    },
+    documents: {
+      type: Array,
+      default() {
+        return [];
+      },
+    },
+    index: {
+      type: Number,
+      default: 0,
+    },
+  },
+
+  computed: {
+    link() {
+      return 'pretty-' + this.documentType + '-link';
+    },
+
+    // We show 10 results centered in index.
+    from() {
+      // If there are less than 5 results after index, we show more results before
+      return this.index - 5 - Math.max(0, this.index + 1 + 5 - this.documents.length);
+    },
+
+    to() {
+      // If there are less than 5 results before index, we show more results after
+      return this.documents.length, this.index + 5 + Math.max(0, 5 - this.index);
+    },
+
+    allResultsQuery() {
+      if (this.documents[0]) {
+        let query = Object.assign({}, this.documents[0].search_query);
+        delete query.limit;
+        delete query.offset;
+        return query;
+      }
+      return null;
+    },
+  },
+
+  methods: {
+    current_index(index) {
+      if (index === this.index) return ['current-document'];
+      else return [];
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.current-document {
+  background-color: hsl(0deg, 0%, 85%);
+}
+</style>

--- a/src/views/documents/DocumentsView.vue
+++ b/src/views/documents/DocumentsView.vue
@@ -130,6 +130,7 @@ import LoadUserPreferencesButton from './utils/LoadUserPreferencesButton';
 import PageSelector from './utils/PageSelector';
 import QueryItems from './utils/QueryItems';
 
+import { add_search_queries } from '@/js/add-search-query';
 import c2c from '@/js/apis/c2c';
 import constants from '@/js/constants';
 
@@ -172,7 +173,11 @@ export default {
       return ['result', 'both'].includes(this.displayMode);
     },
     documents() {
-      return this.promise.data;
+      let documents = this.promise.data;
+      if (documents) {
+        add_search_queries(this.$route.query, documents.documents);
+      }
+      return documents;
     },
     documentType() {
       return this.$route.name.slice(0, -1);

--- a/src/views/documents/utils/ImageCards.vue
+++ b/src/views/documents/utils/ImageCards.vue
@@ -5,6 +5,7 @@
       :key="document.document_id"
       :document="document"
       :title="$documentUtils.getDocumentTitle(document)"
+      :query="$route.query"
       class="card-image"
     >
       <thumbnail :img="document" size="MI" height="250" loading="lazy" />


### PR DESCRIPTION
This is an attempt to fix #3612.

When relevant, list of documents are attached a `search_query` field, containing the query that got them, with bounds centered on them.

Then, when a document is displayed, we are able to get "previous" and "next" documents and generate arrow buttons. We can also generate a list of results "a search navigation box".

A screenshot:
![image](https://github.com/c2corg/c2c_ui/assets/34110029/52b1cbb1-9cd7-4030-a301-3a1ec45e728b)

Questions/warnings/things to improve:
- I will need some help with the visual design!
- When visiting a waypoint, we can click on an associated route and the "associated search" will be the one for all routes associated to this one. BUT: the routes are ordered alphabetically, which is not possible in search queries.
- Similarly, when visiting a waypoint and clicking on an associated route, the search query associated is for all activities. We could restrict it to the activity that was clicked.

Let me know what you think! In my opinion it is very useful to navigate a set of documents using arrows.