### PR TITLE
feat: New "Pin the map to the top of the screen" button

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -61,7 +61,6 @@ export default {
 </script>
 
 <style lang="scss">
-$sidemenu-width: 200px;
 $body-height: calc(100vh - #{$navbar-height});
 
 html {

--- a/src/assets/sass/variables.scss
+++ b/src/assets/sass/variables.scss
@@ -70,6 +70,7 @@ $box-shadow: rgba(10, 10, 10, 0.1) 0 2px 3px 0, rgba(10, 10, 10, 0.1) 0 0 0 1px;
  * locally other varaible if needded (like $navbar-height)
  */
 $navbar-height: 3.25rem;
+$sidemenu-width: 200px;
 
 $input-placeholder-color: rgb(160, 160, 160);
 

--- a/src/components/map/OlMap.vue
+++ b/src/components/map/OlMap.vue
@@ -1,6 +1,10 @@
 <template>
   <div style="width: 100%; height: 100%">
-    <div ref="map" style="width: 100%; height: 100%" @click="showLayerSwitcher = false" />
+    <div
+      ref="map"
+      @click="showLayerSwitcher = false"
+      :class="{ 'pinned-to-top': isPinnedToTop, 'fill-parent': !isPinnedToTop }"
+    />
 
     <div
       ref="layerSwitcherButton"
@@ -12,13 +16,12 @@
       </button>
     </div>
 
-    <!-- FIXME make this a toggle like fullscreen or showLayerSwitcher -->
     <div
-      ref="pinToTopButton"
+      ref="togglePinToTopButton"
       class="ol-control ol-control-pin-to-top"
       :title="$gettext('Pin the map to the top of the screen')"
     >
-      <button @click.stop="pinToTop">
+      <button @click.stop="togglePinToTop">
         <fa-icon icon="fa-regular fa-window-maximize" />
       </button>
     </div>
@@ -313,6 +316,7 @@ export default {
       }),
 
       isFullscreen: false,
+      isPinnedToTop: false,
 
       geolocation: null,
 
@@ -427,7 +431,7 @@ export default {
           zoomOutTipLabel: this.$gettext('Zoom out', 'Map controls'),
         }),
         new ol.control.ScaleLine(),
-        new ol.control.Control({ element: this.$refs.pinToTopButton }),
+        new ol.control.Control({ element: this.$refs.togglePinToTopButton }),
         new ol.control.Control({ element: this.$refs.layerSwitcherButton }),
         new ol.control.Control({ element: this.$refs.layerSwitcher }),
         new ol.control.Control({ element: this.$refs.useMapAsFilter }),
@@ -516,6 +520,7 @@ export default {
   beforeDestroy() {
     this.fullScreenControl.un('enterfullscreen', this.onFullscreenChange);
     this.fullScreenControl.un('leavefullscreen', this.onFullscreenChange);
+    if (this.isPinnedToTop) this.togglePinToTop();
   },
 
   methods: {
@@ -529,28 +534,14 @@ export default {
       return control;
     },
 
-    pinToTop() {
-      // this.isPinned = !this.isPinned;
-      // if (this.isPinned) {
-      var div = document.querySelector('.map-container');
-      div.style.position = 'fixed';
-      div.style.top = '3.25rem'; //  `nav` bar is z=25 fixed; h=3.25
-      div.style.marginTop = 0; // avoid space between nav and map, where body text can be seen while scrolling
-      div.style.left = '200px'; // 'side-menu' is z=30 fixed; w=200px
-      div.style.right = '0px';
-      div.style.zIndex = 10; // on top of body but below nav and side-menu
-      div.style.height = '50%';
-      document.body.style.paddingTop = '50vh'; // as % is relative to width
+    togglePinToTop() {
+      this.isPinnedToTop = !this.isPinnedToTop;
+      if (this.isPinnedToTop) {
+        document.body.style.paddingTop = '50vh'; // as % is relative to width
+      } else {
+        document.body.style.paddingTop = null;
+      }
       this.fitMapToDocuments();
-
-      // if you want a static size instead
-      //div.height=  window.innerHeight / 2 + 'px'
-      //document.body.style.paddingTop = div.offsetHeight + 'px';
-
-      //} else {
-      //  div.style.position = 'relative';
-      // height 275px
-      // marginTop 14
     },
 
     onFullscreenChange() {
@@ -1504,5 +1495,27 @@ $control-margin: 0.5em;
   right: auto;
   left: $control-margin;
   top: 60px;
+}
+
+.fill-parent {
+  width: 100%;
+  height: 100%;
+}
+
+.pinned-to-top {
+  position: fixed;
+  top: $navbar-height;
+  margin-top: 0; /*avoid space between nav and map, where body text can be seen while scrolling*/
+  right: 0px;
+  z-index: 10; /* on top of body but below navbar (z=25) and side-menu (z=30) */
+  height: 50vh;
+  width: 100%;
+  box-shadow: -2px 2px 0 $color-base-c2c;
+}
+
+@media screen and (min-width: $desktop) {
+  .pinned-to-top {
+    left: $sidemenu-width + 2px; /* when is sidemenu shown, as in App.vue */
+  }
 }
 </style>

--- a/src/components/map/OlMap.vue
+++ b/src/components/map/OlMap.vue
@@ -1,10 +1,6 @@
 <template>
   <div style="width: 100%; height: 100%">
-    <div
-      ref="map"
-      @click="showLayerSwitcher = false"
-      :class="{ 'pinned-to-top': isPinnedToTop, 'fill-parent': !isPinnedToTop }"
-    />
+    <div ref="map" style="width: 100%; height: 100%" @click="showLayerSwitcher = false" />
 
     <div
       ref="layerSwitcherButton"
@@ -17,11 +13,12 @@
     </div>
 
     <div
+      v-show="showPinToTopButton"
       ref="togglePinToTopButton"
       class="ol-control ol-control-pin-to-top"
       :title="$gettext('Pin the map to the top of the screen')"
     >
-      <button @click.stop="togglePinToTop">
+      <button @click.stop="$emit('pin-to-top-clicked')">
         <fa-icon icon="fa-regular fa-window-maximize" />
       </button>
     </div>
@@ -263,6 +260,11 @@ export default {
       type: String,
       default: null,
     },
+
+    showPinToTopButton: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data() {
@@ -316,7 +318,6 @@ export default {
       }),
 
       isFullscreen: false,
-      isPinnedToTop: false,
 
       geolocation: null,
 
@@ -520,7 +521,6 @@ export default {
   beforeDestroy() {
     this.fullScreenControl.un('enterfullscreen', this.onFullscreenChange);
     this.fullScreenControl.un('leavefullscreen', this.onFullscreenChange);
-    if (this.isPinnedToTop) this.togglePinToTop();
   },
 
   methods: {
@@ -532,16 +532,6 @@ export default {
       control.on('enterfullscreen', this.onFullscreenChange);
       control.on('leavefullscreen', this.onFullscreenChange);
       return control;
-    },
-
-    togglePinToTop() {
-      this.isPinnedToTop = !this.isPinnedToTop;
-      if (this.isPinnedToTop) {
-        document.body.style.paddingTop = '50vh'; // as % is relative to width
-      } else {
-        document.body.style.paddingTop = null;
-      }
-      this.fitMapToDocuments();
     },
 
     onFullscreenChange() {
@@ -1495,27 +1485,5 @@ $control-margin: 0.5em;
   right: auto;
   left: $control-margin;
   top: 60px;
-}
-
-.fill-parent {
-  width: 100%;
-  height: 100%;
-}
-
-.pinned-to-top {
-  position: fixed;
-  top: $navbar-height;
-  margin-top: 0; /*avoid space between nav and map, where body text can be seen while scrolling*/
-  right: 0px;
-  z-index: 10; /* on top of body but below navbar (z=25) and side-menu (z=30) */
-  height: 50vh;
-  width: 100%;
-  box-shadow: -2px 2px 0 $color-base-c2c;
-}
-
-@media screen and (min-width: $desktop) {
-  .pinned-to-top {
-    left: $sidemenu-width + 2px; /* when is sidemenu shown, as in App.vue */
-  }
 }
 </style>

--- a/src/components/map/OlMap.vue
+++ b/src/components/map/OlMap.vue
@@ -12,6 +12,17 @@
       </button>
     </div>
 
+    <!-- FIXME make this a toggle like fullscreen or showLayerSwitcher -->
+    <div
+      ref="pinToTopButton"
+      class="ol-control ol-control-pin-to-top"
+      :title="$gettext('Pin the map to the top of the screen')"
+    >
+      <button @click.stop="pinToTop">
+        <fa-icon icon="fa-regular fa-window-maximize" />
+      </button>
+    </div>
+
     <div v-show="showLayerSwitcher" ref="layerSwitcher" class="ol-control ol-control-layer-switcher" @click.stop="">
       <div class="ol-control-layer-switcher-layers">
         <header v-translate>Base layer</header>
@@ -416,6 +427,7 @@ export default {
           zoomOutTipLabel: this.$gettext('Zoom out', 'Map controls'),
         }),
         new ol.control.ScaleLine(),
+        new ol.control.Control({ element: this.$refs.pinToTopButton }),
         new ol.control.Control({ element: this.$refs.layerSwitcherButton }),
         new ol.control.Control({ element: this.$refs.layerSwitcher }),
         new ol.control.Control({ element: this.$refs.useMapAsFilter }),
@@ -515,6 +527,30 @@ export default {
       control.on('enterfullscreen', this.onFullscreenChange);
       control.on('leavefullscreen', this.onFullscreenChange);
       return control;
+    },
+
+    pinToTop() {
+      // this.isPinned = !this.isPinned;
+      // if (this.isPinned) {
+      var div = document.querySelector('.map-container');
+      div.style.position = 'fixed';
+      div.style.top = '3.25rem'; //  `nav` bar is z=25 fixed; h=3.25
+      div.style.marginTop = 0; // avoid space between nav and map, where body text can be seen while scrolling
+      div.style.left = '200px'; // 'side-menu' is z=30 fixed; w=200px
+      div.style.right = '0px';
+      div.style.zIndex = 10; // on top of body but below nav and side-menu
+      div.style.height = '50%';
+      document.body.style.paddingTop = '50vh'; // as % is relative to width
+      this.fitMapToDocuments();
+
+      // if you want a static size instead
+      //div.height=  window.innerHeight / 2 + 'px'
+      //document.body.style.paddingTop = div.offsetHeight + 'px';
+
+      //} else {
+      //  div.style.position = 'relative';
+      // height 275px
+      // marginTop 14
     },
 
     onFullscreenChange() {
@@ -1266,8 +1302,13 @@ export default {
 <style lang="scss" scoped>
 $control-margin: 0.5em;
 
+.ol-control-pin-to-top {
+  top: 80px;
+  left: $control-margin;
+}
+
 .ol-control-center-on-geolocation {
-  top: 100px;
+  top: 120px;
   left: $control-margin;
 }
 

--- a/src/js/vue-plugins/font-awesome-config.js
+++ b/src/js/vue-plugins/font-awesome-config.js
@@ -8,6 +8,7 @@ import { faCircle as faCircleRegular } from '@fortawesome/free-regular-svg-icons
 import { faClock as faClockRegular } from '@fortawesome/free-regular-svg-icons/faClock';
 import { faHourglass as faHourglassRegular } from '@fortawesome/free-regular-svg-icons/faHourglass';
 import { faTrashAlt as faTrashAltRegular } from '@fortawesome/free-regular-svg-icons/faTrashAlt';
+import { faWindowMaximize as faWindowMaximizeRegular } from '@fortawesome/free-regular-svg-icons/faWindowMaximize';
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons/faAngleDown';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons/faArrowRight';
@@ -358,6 +359,7 @@ export default function install(Vue) {
     faClockRegular,
     faHourglassRegular,
     faTrashAltRegular,
+    faWindowMaximizeRegular,
 
     // brands icons
     faCreativeCommons,

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -509,6 +509,7 @@
     "Personal feed off": "Fil personnel désactivé",
     "Personal feed on": "Fil personnel activé",
     "Personal informations": "Informations personnelles",
+    "Pin the map to the top of the screen": "Épingler la carte en haut de l'écran",
     "Pitch description tag": "Balise de description des longueurs",
     "Please describe your technical and experience level related to the chosen goal, your level of fitness, prior tiredness accumulated, acclimatization if in altitude, etc.": "Décrivez votre niveau technique et expérience par rapport à l’objectif choisi, votre condition physique, la fatigue accumulée avant la sortie, l’acclimatation pour une sortie en altitude, etc.",
     "Please move the map, or change the route's name.": "Déplacez la carte, ou modifier le nom de l'itinéraire.",


### PR DESCRIPTION
Community discussion: **[[Cahier des charges][UX] - Carte plus grande](https://forum.camptocamp.org/t/cahier-des-charges-ux-carte-plus-grande/293938/3)**

Just a request for comments for now.

Known bugs:
* ~Blank space in place of the small map~ *fixed by moving logic to `MapBox`*
* ~Blank space when navigating away from the map~ *fixed with `beforeDestroy`*
* ~Jerky behavior on mobile when browser's url bar hides/shows~ *fixed by using `vh` instead of %*
* ~`fitMapToDocuments` works but remains a bit too "zoomed out" probably because `map.getSize()` is not updated yet~ *fixed with setTimeout*

Known missing:
* No "toggled" icon for the button (like fullscreen has... but is it needed here?)
* ~Missing separation line below map~ *fixed with `box-shadow`*
* Translations

The button should not be available on *all* maps of camptocamp, just the ones where it's useful:

  * ✕ not shown on topo/outing edit (`.*EditionView` using MapInputRow), but I think it can be useful
  * ✓ not shown anymore on DocumentsView (eg [Outings](https://www.camptocamp.org/)), DiffView (no idea about this one)
  * ✓ not shown on YETI
  * ✓✓ shown and useful in RouteView, OutingView, [WaypointView](https://www.camptocamp.org/waypoints/103406)
  * ✓✓ neutral in [ImageView](https://www.camptocamp.org/images/1589643), [BookView](https://www.camptocamp.org/books/14652), [AreaView](https://www.camptocamp.org/areas/1381796/), [XReportView](https://www.camptocamp.org/xreports/1587593) - ok to keep for consistency IMO
  * ? shown but no idea what this is: ProfileView (no map on my profile at least...)