### PR TITLE
feat: #2552 capitalize rock free rating for bloc

### DIFF
--- a/src/components/generics/DocumentRating.vue
+++ b/src/components/generics/DocumentRating.vue
@@ -11,7 +11,7 @@
 
       <span>
         <span v-if="document.rock_free_rating" :title="$gettext('rock_free_rating')">
-          {{ document.rock_free_rating
+          {{ rockFreeRating
           }}<!--
               --></span
         ><!--
@@ -148,6 +148,11 @@ export default {
       }
 
       return result;
+    },
+    rockFreeRating() {
+      const rating = this.document.rock_free_rating;
+      if (this.document.climbing_outdoor_type !== 'bloc') return rating;
+      return rating.toUpperCase();
     },
   },
 

--- a/src/views/wiki/edition/RouteEditionView.vue
+++ b/src/views/wiki/edition/RouteEditionView.vue
@@ -195,6 +195,12 @@ export default {
     'document.associations.waypoints': 'onWaypointsAssociation',
     'document.geometry.geom': 'onGeometryUpdate',
     'document.geometry.geom_detail': 'onGeometryUpdate',
+    'document.climbing_outdoor_type': {
+      handler(climbingType) {
+        this.handleRockFreeRating(climbingType);
+      },
+      immediate: true,
+    },
   },
 
   methods: {
@@ -202,6 +208,18 @@ export default {
       // on creation from a waypoint, set this waypoint as main
       if (this.mode === 'add' && this.$route.query.w) {
         this.document.main_waypoint_id = parseInt(this.$route.query.w);
+      }
+    },
+
+    beforeSave() {
+      if (this.document.climbing_outdoor_type === 'bloc') {
+        this.handleRockFreeRating('single');
+      }
+    },
+
+    afterSave() {
+      if (this.document.climbing_outdoor_type === 'bloc') {
+        this.handleRockFreeRating('bloc');
       }
     },
 
@@ -224,6 +242,20 @@ export default {
       // on creation mode, if main waypoint is null, and some waypoints are associated, take the first
       if (this.mode === 'add' && this.document.main_waypoint_id === null && waypoints.length !== 0) {
         this.document.main_waypoint_id = waypoints[0].document_id;
+      }
+    },
+
+    handleRockFreeRating(climbingType) {
+      const documentRating = this.document.rock_free_rating;
+      const ratings = this.fields.rock_free_rating.values;
+      switch (climbingType) {
+        case 'bloc':
+          this.document.rock_free_rating = documentRating.toUpperCase();
+          this.fields.rock_free_rating.values = ratings.map((grade) => grade.toUpperCase());
+          break;
+        default:
+          this.document.rock_free_rating = documentRating.toLowerCase();
+          this.fields.rock_free_rating.values = ratings.map((grade) => grade.toLowerCase());
       }
     },
   },

--- a/src/views/wiki/edition/utils/document-edition-view-mixin.js
+++ b/src/views/wiki/edition/utils/document-edition-view-mixin.js
@@ -209,6 +209,8 @@ export default {
 
     beforeSave() {},
 
+    afterSave() {},
+
     // display a popup with info from fields that contains an error
     // return true if popup is displayed, false otherwise
     displayErrors(isApiMessage) {
@@ -269,6 +271,8 @@ export default {
           this.goToDocument(response.data.document_id);
         });
       }
+
+      this.afterSave(); // allow each view to handle some specific cases
 
       promise.catch((error) => {
         this.saving = false;


### PR DESCRIPTION
Hi! Here is a PR trying to solve https://github.com/c2corg/c2c_ui/issues/2552

I've taken into account what had been suggested in this PR : https://github.com/c2corg/c2c_ui/pull/2971.  So, here is a solution that is :
- front-end only
- use a computed property to capitalize the boulder grade (in DocumentRatingComponent.vue)
- capitalize the boulder grade field and options in the create/edit form

I wanted to encapsulate the logic to convert sport climbing grade to boulder grade (and boulder grade  -> sport climbing grade) somewhere but I didn't find an appropriate place so I've let it inside the components.   

FYI: I've considered creating a new type of "form field" especially for boulder grade but I think it would have required more changes and a kind of duplication (as boulder grades are just sport climbing grade with a capital letter).

FYI2: I've not been able to persist data locally when I've tried to edit/create a new route (with or without the changes of this PR), I guess some entities schema changed and the docker images had not been updated, but I'm not sure 