### PR TITLE
chore: #3768 use openresty debian bookworm as production base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN node tools/generate-health.js
 
 # production stage
 FROM openresty/openresty:bookworm as production-stage
+RUN apt-get update && apt-get install -y gettext-base # required to use envsubst
 COPY --from=build-stage /dist /usr/share/nginx/html
 COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf.template
 
@@ -18,8 +19,5 @@ COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf.template
 ENV PORT 80
 ENV HEALTH_HTTP_PORT 8080
 ENV SERVER_NAME _
-
-# Required to use envsubst
-RUN apt-get update && apt-get install -y gettext-base
 
 CMD ["sh", "-c", "envsubst '${PORT},${HEALTH_HTTP_PORT},${SERVER_NAME}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && /usr/bin/openresty -g 'daemon off;'"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 RUN node tools/generate-health.js
 
 # production stage
-FROM openresty/openresty:bullseye as production-stage
+FROM openresty/openresty:bookworm as production-stage
 COPY --from=build-stage /dist /usr/share/nginx/html
 COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf.template
 
@@ -18,5 +18,8 @@ COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf.template
 ENV PORT 80
 ENV HEALTH_HTTP_PORT 8080
 ENV SERVER_NAME _
+
+# Required to use envsubst
+RUN apt-get update && apt-get install -y gettext-base
 
 CMD ["sh", "-c", "envsubst '${PORT},${HEALTH_HTTP_PORT},${SERVER_NAME}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && /usr/bin/openresty -g 'daemon off;'"]


### PR DESCRIPTION
Hi! Here is a PR to use the last debian version (bookworm) for the openresty base docker image as suggested in this issue https://github.com/c2corg/c2c_ui/issues/3768.

Here is a solution for variable substitution using **sed**  instead of  **envsubst** as it was not provided with this debian version.