### PR TITLE
fix: #2085 display GPS coordinate input

### DIFF
--- a/src/views/wiki/edition/utils/MapInputRow.vue
+++ b/src/views/wiki/edition/utils/MapInputRow.vue
@@ -28,13 +28,13 @@
           @move="$emit('move', arguments[0])"
         />
       </div>
-      <div class="column is-6 is-hidden">
+      <div class="column is-6">
         <div class="field">
           <label class="label">{{ $gettext('Longitude') }}</label>
           <input-simple type="number" postfix="°E" v-model="longitude" @input="setGeometryPoint" />
         </div>
       </div>
-      <div class="column is-6 is-hidden">
+      <div class="column is-6">
         <div class="field">
           <label class="label">{{ $gettext('Latitude') }}</label>
           <input-simple type="number" postfix="°N" v-model="latitude" @input="setGeometryPoint" />


### PR DESCRIPTION
display GPS coordinate input below all editor maps (waypoint, outing, topo, user...) (regression from 13d082d)