### PR TITLE
feat: #3755 add author in diaporama

### DIFF
--- a/src/components/image-viewer/ImageInfo.vue
+++ b/src/components/image-viewer/ImageInfo.vue
@@ -17,6 +17,13 @@
         </label>
       </p>
 
+      <p v-if="author">
+        <fa-icon icon="user" />
+        <label>
+          {{ author }}
+        </label>
+      </p>
+
       <markdown v-if="document.cooked.summary" class="is-italic" :content="document.cooked.summary" />
       <markdown v-if="document.cooked.description" :content="document.cooked.description" />
 
@@ -57,6 +64,9 @@ export default {
   computed: {
     document() {
       return this.promise.data ? this.promise.data : null;
+    },
+    author() {
+      return this.document.author ? this.document.author : this.document.creator?.name;
     },
   },
 


### PR DESCRIPTION
Here is a solution for https://github.com/c2corg/c2c_ui/issues/3755

Add author in diaporama, it look like this:

![Untitled](https://github.com/c2corg/c2c_ui/assets/52289507/2fcd8392-b67a-48f4-842a-cd084487d62f)

I've used the property `document.creator.name` as `document.author` datas seems null everytime, not sure about this