### PR TITLE
feat: Add "Join us" button in navigation

### DIFF
--- a/src/components/generics/icons/IconJoinUs.vue
+++ b/src/components/generics/icons/IconJoinUs.vue
@@ -1,0 +1,14 @@
+<template>
+  <fa-icon icon="user-plus" :fixed-width="fixedWidth" />
+</template>
+
+<script>
+export default {
+  props: {
+    fixedWidth: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>

--- a/src/components/generics/links/JoinUsLink.vue
+++ b/src/components/generics/links/JoinUsLink.vue
@@ -1,0 +1,30 @@
+<template>
+  <span>
+    <a
+      :href="
+        'https://www.helloasso.com/associations/camptocamp-association/adhesions/adhesions-' +
+        currentYear +
+        '-camptocamp-association'
+      "
+      :title="$gettext('Join us')"
+    >
+      <slot />
+    </a>
+  </span>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      currentYear: this.getCurrentYearString(),
+    };
+  },
+
+  methods: {
+    getCurrentYearString() {
+      return this.$dateUtils.toLocalizedString(new Date(), 'YYYY');
+    },
+  },
+};
+</script>

--- a/src/js/vue-plugins/font-awesome-config.js
+++ b/src/js/vue-plugins/font-awesome-config.js
@@ -119,6 +119,7 @@ import { faUpload } from '@fortawesome/free-solid-svg-icons/faUpload';
 import { faUser } from '@fortawesome/free-solid-svg-icons/faUser';
 import { faUserCheck } from '@fortawesome/free-solid-svg-icons/faUserCheck';
 import { faUserLock } from '@fortawesome/free-solid-svg-icons/faUserLock';
+import { faUserPlus } from '@fortawesome/free-solid-svg-icons/faUserPlus';
 import { faUserShield } from '@fortawesome/free-solid-svg-icons/faUserShield';
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers';
 import { faWrench } from '@fortawesome/free-solid-svg-icons/faWrench';
@@ -350,6 +351,7 @@ export default function install(Vue) {
     faUser,
     faUserCheck,
     faUserLock,
+    faUserPlus,
     faUsers,
     faUserShield,
     faWrench,

--- a/src/views/Navigation.vue
+++ b/src/views/Navigation.vue
@@ -73,6 +73,13 @@
       </div>
 
       <div class="navigation-item">
+        <join-us-link class="has-text-centered button c2c-color" :class="{ 'is-hidden-mobile': !hideSearchInput }">
+          <icon-join-us fixed-width />
+          <span class="is-hidden-mobile">{{ $gettext('Join us') | uppercaseFirstLetter }}</span>
+        </join-us-link>
+      </div>
+
+      <div class="navigation-item">
         <dropdown-button class="is-right add-button" ref="addDocumentMenu">
           <span slot="button" class="button is-success">
             <fa-icon icon="plus" />
@@ -156,10 +163,16 @@
 
 <script>
 import IconHelp from '@/components/generics/icons/IconHelp';
+import IconJoinUs from '@/components/generics/icons/IconJoinUs';
+import JoinUsLink from '@/components/generics/links/JoinUsLink.vue';
 import config from '@/js/config';
 
 export default {
-  components: { IconHelp },
+  components: {
+    IconHelp,
+    IconJoinUs,
+    JoinUsLink,
+  },
   data() {
     return {
       searchText: '',
@@ -302,6 +315,10 @@ nav {
   line-height: 1.5;
 }
 
+.c2c-color {
+  background-color: $color-base-c2c;
+}
+
 @media screen and (max-width: $tablet) {
   .navigation-brand {
     img {
@@ -311,7 +328,7 @@ nav {
   }
 
   .navigation-item {
-    padding: 0.5rem 5px;
+    padding: 0.5rem 0.1rem;
   }
 
   .navigation-end {
@@ -331,7 +348,7 @@ nav {
   }
 
   .navigation-item {
-    padding: 0.5rem 5px;
+    padding: 0.5rem 0.2rem;
   }
 
   .navigation-end {
@@ -408,6 +425,10 @@ nav {
 </style>
 
 <style lang="scss">
+.c2c-color > a {
+  color: $color-text;
+}
+
 @media screen and (max-width: $tablet) {
   .add-button .dropdown-content {
     position: fixed;


### PR DESCRIPTION
To improve the visibility of c2c association, as discussed in board, this button links directly to join-us campaign of the current year.
Specific icon and link could be re-used for link on sidemenu or elsewhere.