### PR TITLE
fix: #3571 recenter on map search

### DIFF
--- a/src/components/map/OlMap.vue
+++ b/src/components/map/OlMap.vue
@@ -1170,18 +1170,10 @@ export default {
     // https://github.com/c2corg/v6_ui/blob/c9962a6c3bac0670eab732d563f9f480379f84d1/c2corg_ui/static/js/map/search.js#L194
     recenterOn(item) {
       const feature = geoJSONFormat.readFeature(item);
-      let extent = feature.get('extent');
       let coordinates = feature.getGeometry().flatCoordinates;
-
-      if (extent) {
-        extent = ol.proj.transformExtent(extent, 'EPSG:4326', 'EPSG:3857');
-        this.view.fit(extent, { size: this.map.getSize(), maxZoom: 12 });
-      } else {
-        coordinates = ol.proj.transform(coordinates, 'EPSG:4326', 'EPSG:3857');
-        this.view.setCenter(coordinates);
-        this.view.setZoom(16);
-      }
-
+      coordinates = ol.proj.transform(coordinates, 'EPSG:4326', 'EPSG:3857');
+      this.view.setCenter(coordinates);
+      this.view.setZoom(16);
       this.showRecenterOnPropositions = false;
     },
 


### PR DESCRIPTION
Here is a PR to fix https://github.com/c2corg/c2c_ui/issues/3571

Not sure why the condition `if(extent)` was necessary, the problem was (cf changes for reference):
 -  `let extent = feature.get('extent');` is truthy
 -  `extent = ol.proj.transformExtent(extent, 'EPSG:4326', 'EPSG:3857');` set `extent` to `[Infinity, Infinity, Infinity, Infinity]`
 -  So `this.view.fit(extent, { size: this.map.getSize(), maxZoom: 12 });` return an error
 
My guess is that `transformExtent` needs an extent parameter with the following type according to the declaration file:

````
/**
 * An array of numbers representing an extent: `[minx, miny, maxx, maxy]`.
 */
export type Extent = Array<number>;
````

...and I'm not sure the value passed to `transformExtent` has the right type (`[minx, maxx, miny, maxy]`) I guess.