### PR TITLE
fix(yeti): Use own WMS server

### DIFF
--- a/src/components/yeti/map-layers/WinterRouteLayer.vue
+++ b/src/components/yeti/map-layers/WinterRouteLayer.vue
@@ -35,8 +35,8 @@ export default {
     // then  set source
     this.layer.setSource(
       new ol.source.TileWMS({
-        url: 'https://wxs.ign.fr/an7nvfzojv5wa96dsga5nk8w/geoportail/v/wms',
-        params: { LAYERS: 'TRACERANDOHIVERNALE' },
+        url: 'https://api.ensg.eu/geoserver/yeti/wms',
+        params: { LAYERS: 'yeti:TRACERANDOHIVERNALE' },
         attributions: '<a href="https://www.petzl.com/fondation/s/?language=fr">© PETZL</a>',
       })
     );


### PR DESCRIPTION
This is an important fix.
It uses our own WMS server for winter hiking routes, instead of IGN's one.