### PR TITLE
feat: #2648 outings view count

### DIFF
--- a/src/components/generics/icons/IconViewCount.vue
+++ b/src/components/generics/icons/IconViewCount.vue
@@ -1,0 +1,14 @@
+<template>
+  <fa-icon icon="eye" :fixed-width="fixedWidth" />
+</template>
+
+<script>
+export default {
+  props: {
+    fixedWidth: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>

--- a/src/js/constants/documentsProperties.json
+++ b/src/js/constants/documentsProperties.json
@@ -150,6 +150,7 @@
       { "id": "dates", "properties": { "url": "date", "required": false } },
       { "id": "disable_comments" },
       { "id": "disable_view_count" },
+      { "id": "view_count" },
       { "id": "elevation_access", "properties": { "url": "oparka" } },
       {
         "id": "elevation_down_snow",

--- a/src/js/constants/documentsProperties.json
+++ b/src/js/constants/documentsProperties.json
@@ -149,6 +149,7 @@
       { "id": "date_start", "properties": { "url": "date", "required": false } },
       { "id": "dates", "properties": { "url": "date", "required": false } },
       { "id": "disable_comments" },
+      { "id": "disable_view_count" },
       { "id": "elevation_access", "properties": { "url": "oparka" } },
       {
         "id": "elevation_down_snow",

--- a/src/js/constants/fieldsProperties.json
+++ b/src/js/constants/fieldsProperties.json
@@ -237,6 +237,9 @@
     "type": "boolean",
     "default": false
   },
+  "view_count": {
+    "type": "number"
+  },
   "durations": {
     "values": "route_duration_types",
     "multiple": true,

--- a/src/js/constants/fieldsProperties.json
+++ b/src/js/constants/fieldsProperties.json
@@ -233,6 +233,10 @@
     "type": "boolean",
     "default": false
   },
+  "disable_view_count": {
+    "type": "boolean",
+    "default": false
+  },
   "durations": {
     "values": "route_duration_types",
     "multiple": true,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -376,6 +376,7 @@
     "difficulties_height": "Difficulties start altitude",
     "disable_comments": "Disable comments",
     "disable_view_count": "Disable view count",
+    "view_count": "views",
     "durations": "Durations",
     "durations (days)": "duration (days)",
     "easy": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -375,6 +375,7 @@
     },
     "difficulties_height": "Difficulties start altitude",
     "disable_comments": "Disable comments",
+    "disable_view_count": "Disable view count",
     "durations": "Durations",
     "durations (days)": "duration (days)",
     "easy": {

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1007,6 +1007,7 @@
     },
     "difficulties_height": "Altitude du début des difficultés",
     "disable_comments": "Désactiver les commentaires",
+    "disable_view_count": "Désactiver le compteur de vues",
     "draft": {
       "quality_types": "ébauche"
     },

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1008,6 +1008,7 @@
     "difficulties_height": "Altitude du début des difficultés",
     "disable_comments": "Désactiver les commentaires",
     "disable_view_count": "Désactiver le compteur de vues",
+    "view_count": "vues",
     "draft": {
       "quality_types": "ébauche"
     },

--- a/src/views/document/utils/boxes/ToolBox.vue
+++ b/src/views/document/utils/boxes/ToolBox.vue
@@ -81,6 +81,11 @@
       <span>{{ quality.i18nName }}</span> {{ quality.i18nValue }}
     </div>
 
+    <div class="view-count" v-if="viewCount">
+      <icon-view-count fixed-width></icon-view-count>
+      {{ viewCount.value }} <span>{{ viewCount.i18nName }}</span>
+    </div>
+
     <tool-box-button
       v-if="isEditable"
       :to="{ name: documentType + '-edit', params: { id: document.document_id, lang: lang } }"
@@ -177,6 +182,7 @@
 
 <script>
 import IconQuality from '../../../../components/generics/icons/IconQuality.vue';
+import IconViewCount from '../../../../components/generics/icons/IconViewCount.vue';
 import DeleteDocumentWindow from '../windows/DeleteDocumentWindow';
 import DeleteLocaleWindow from '../windows/DeleteLocaleWindow';
 import MergeDocumentWindow from '../windows/MergeDocumentWindow';
@@ -203,6 +209,7 @@ export default {
     LicenseBox,
     AssociatedDocuments,
     IconQuality,
+    IconViewCount,
     AssociationsWindow,
     DeleteLocaleWindow,
     DeleteDocumentWindow,
@@ -266,6 +273,20 @@ export default {
         value: this.document[fields.quality.name],
         i18nName: this.$gettext(fields.quality.name),
         i18nValue: this.$gettext(this.document[fields.quality.name], fields.quality.i18nContext),
+      };
+    },
+
+    viewCount() {
+      const fields = constants.objectDefinitions[this.documentType].fields;
+      const value = this.document[fields.view_count.name];
+      const isValue = value !== null && value !== undefined;
+      if (!fields.view_count || !isValue) {
+        return;
+      }
+      return {
+        ...fields.view_count,
+        value,
+        i18nName: this.$gettext(fields.view_count.name),
       };
     },
 
@@ -418,7 +439,7 @@ export default {
   content: ' \2022 '; /* \2022 is bull */
 }
 
-.quality {
+.quality .view-count {
   span:nth-of-type(1) {
     @include colon;
   }

--- a/src/views/wiki/edition/OutingEditionView.vue
+++ b/src/views/wiki/edition/OutingEditionView.vue
@@ -149,6 +149,9 @@
         />
         <form-field :document="document" :field="fields.disable_comments" />
       </div>
+      <div class="columns">
+        <form-field :document="document" :field="fields.disable_view_count" />
+      </div>
     </form-section>
 
     <form-section


### PR DESCRIPTION
For https://github.com/c2corg/c2c_ui/issues/2648

According to https://forum.camptocamp.org/t/cahier-des-charges-compteur-de-vues-pour-les-sorties/305151/18?u=loic_p

## Important
Needs to be reviewed after https://github.com/c2corg/v6_api/pull/1726 and https://github.com/c2corg/v6_api/pull/1731 have been merged


## How to test 
Create a new outing, play with the `disable view count` field and open the same outing without being connected or being connected with another account  

![Screenshot from 2024-01-23 16-27-09](https://github.com/c2corg/c2c_ui/assets/52289507/c2b68367-8d6d-4aa6-934d-af8d48d9fab3)

![test](https://github.com/c2corg/c2c_ui/assets/52289507/31b87022-7490-482d-a1ad-9bb5e870d746)

PS: I'm not sure if it's okay to update translation files as it seems to be generated with transiflex