### PR TITLE
feat: improve fix #1315 to allow zoomed image to occupy the whole viewport

### DIFF
--- a/src/components/image-viewer/ImageViewer.vue
+++ b/src/components/image-viewer/ImageViewer.vue
@@ -2,7 +2,7 @@
   <div v-if="visible" class="image-viewer" :class="{ 'hide-buttons': hideButtons }">
     <div class="is-flex has-text-grey-lighter image-viewer-header">
       <span class="is-size-4 is-ellipsed-tablet image-viewer-title">
-        {{ activeDocument.locales[0].title || '&nbsp;' }}
+        {{ activeDocument.locales[0].title }}
       </span>
       <span class="is-size-3 is-nowrap image-viewer-buttons">
         <document-link :document="activeDocument" class="has-text-grey-lighter">
@@ -267,6 +267,10 @@ $paginationHeight: 30px;
   background: rgba(0, 0, 0, 0.95);
 
   &-header {
+    position: absolute;
+    left: 0;
+    right: 0;
+    z-index: 3;
     justify-content: space-between;
     padding: 0.5rem 1rem;
     margin-bottom: 0 !important;
@@ -274,30 +278,49 @@ $paginationHeight: 30px;
 
     .image-viewer-title {
       margin: auto;
+      // display title on top of the image with some alpha background
+      // in case it overlaps (eg when zooming or on mobile)
+      z-index: 2;
+      background: rgba(0, 0, 0, 0.4);
+      border-radius: 10px;
+      padding: 0 10px;
     }
 
     .image-viewer-buttons > *:not(:last-child) {
       margin-right: 0.75rem;
     }
 
-    .image-viewer-buttons {
+    .image-viewer-buttons > * {
+      // keep the buttons visible when they overlap the image
+      filter: drop-shadow(2px 2px 2px black);
       svg:hover {
         color: white;
       }
     }
   }
 
+  // the img container
   &-swiper {
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    z-index: 0;
     width: 100vw;
-    // on mobile, we don't have pagination, but this will give enough space to display
-    // the title on one line.
-    height: calc(100% - #{$headerHeight} - #{$paginationHeight});
+    height: 100%;
+
+    @media screen and (min-width: $tablet) {
+      & .swiper-zoom-container {
+        // adjust the initial centering of the img to avoid overlap with 1st line of title
+        margin-top: 10px;
+      }
+    }
   }
 
   &-slide {
     overflow: hidden;
 
     img {
+      // initially avoid overlap with title & scroll, but this is overridden when zooming
       max-height: calc(100vh - #{$headerHeight} - #{$paginationHeight});
     }
   }
@@ -308,6 +331,7 @@ $paginationHeight: 30px;
     justify-content: center;
     bottom: 0;
     height: $paginationHeight;
+    position: fixed;
 
     .image-viewer-bullet {
       display: inline-block;
@@ -353,17 +377,14 @@ $paginationHeight: 30px;
 }
 
 @media screen and (max-width: $tablet) {
-  .image-viewer-title {
-    position: absolute;
+  .image-viewer-header .image-viewer-title {
+    position: fixed;
+    // on mobile, title is below to avoid overlap with the toolbox
     bottom: 0;
     left: 0;
     width: 100%;
     text-align: center;
-    // since mobile are small, we don't do text ellipsis and allow multi line text
-    // make it displayed on top of the image, and with some alpha background in case it
-    // overlaps the image
-    z-index: 2;
-    background: rgba(0, 0, 0, 0.6);
+    border-radius: unset;
   }
 
   .image-viewer-buttons {


### PR DESCRIPTION
The title, navbar and buttons are still always visible on top of the image. The navbar is hidden on mobile (<769px) as before

before there were big black bars even when zooming:

![image](https://github.com/c2corg/c2c_ui/assets/2772505/07f12add-67be-4b4f-a202-5313a54c54a0)

After:

![image](https://github.com/c2corg/c2c_ui/assets/2772505/e5527889-8b2e-4fb7-bb68-16741f9b0591)


The initial view (when clicking an image, before zooming) remains the same on desktop: before/after:

![Screenshot_20240127_210035](https://github.com/c2corg/c2c_ui/assets/2772505/50313ea6-f557-45fa-ad43-5e3f83396ba0)

but it slightly more zoomed in some cases on mobile - not perfect but I'm giving up :sweat_smile: :

before:

![image](https://github.com/c2corg/c2c_ui/assets/2772505/198f2bd6-742f-4e41-b9f6-6f75865634df)


after:

![image](https://github.com/c2corg/c2c_ui/assets/2772505/7925f9ad-a417-41c1-8203-4cfac46fe13d)

Tested with Chrome and FF on Android Pixel 8 Pro and Linux Ubuntu ; tests on Safari would be nice.