### PR TITLE
feat: #3713 show ToS checkbox if ToS error on login

### DIFF
--- a/src/js/apis/c2c/UserProfileService.js
+++ b/src/js/apis/c2c/UserProfileService.js
@@ -64,11 +64,12 @@ function UserProfileService(api) {
   };
 }
 
-UserProfileService.prototype.login = function (username, password) {
+UserProfileService.prototype.login = function (username, password, acceptTos) {
   return this.api.post('/users/login', {
     username,
     password,
     discourse: true,
+    accept_tos: acceptTos,
   });
 };
 

--- a/src/js/vue-plugins/user.js
+++ b/src/js/vue-plugins/user.js
@@ -57,8 +57,8 @@ export default function install(Vue) {
     },
 
     methods: {
-      signIn(username, password) {
-        return c2c.userProfile.login(username, password).then((response) => {
+      signIn(username, password, acceptTos) {
+        return c2c.userProfile.login(username, password, acceptTos).then((response) => {
           this.lang = response.data.lang;
           this.token = response.data.token;
           this.roles = response.data.roles;


### PR DESCRIPTION
One attempt to solve https://github.com/c2corg/c2c_ui/issues/3713

As written in , https://github.com/c2corg/v6_api/pull/1542 should be merged first.

![image](https://github.com/c2corg/c2c_ui/assets/52289507/a88d8ad8-5354-4003-a4af-b0f59929346b)

## How to test:

- For the backend checkout to the branch used in this PR: https://github.com/c2corg/v6_api/pull/1542 and run the migrations
- Launch the web app and try to login with any existing users (username: user590, mdp: c2c for instance), it should de facto fail as no users has accepted the ToS.
- When it fail it should show the reason why it fail above the login form and if it's because the user didn't accept the ToS it should show a checkbox below the password field. If you check the box and press login it should successfully login
    