### PR TITLE
feat: #3697 add waypoints external resources section

### DIFF
--- a/src/js/constants/documentsProperties.json
+++ b/src/js/constants/documentsProperties.json
@@ -650,7 +650,8 @@
       { "id": "books", "properties": { "url": "b", "associationEditorOrder": 2 } },
       { "id": "images", "properties": { "associationEditorOrder": 4 } },
       { "id": "waypoints", "properties": { "url": "w", "associationEditorOrder": 1 } },
-      { "id": "waypoints", "properties": { "name": "waypoint_children", "url": "w", "associationEditorOrder": 1 } }
+      { "id": "waypoints", "properties": { "name": "waypoint_children", "url": "w", "associationEditorOrder": 1 } },
+      { "id": "external_resources" }
     ]
   },
 

--- a/src/views/document/WaypointView.vue
+++ b/src/views/document/WaypointView.vue
@@ -114,7 +114,7 @@
           </div>
         </div>
 
-        <div class="box" v-if="locale.summary || locale.access_period || locale.description || locale.access">
+        <div class="box" v-if="showMainBox">
           <markdown-section :document="document" :field="fields.summary" />
           <markdown-section :document="document" :field="fields.access_period" :title="accessPeriodTitle" />
           <template v-if="document.waypoint_type == 'access'">
@@ -126,6 +126,7 @@
             <markdown-section :document="document" :field="fields.description" :title="descriptionTitle" />
             <markdown-section :document="document" :field="fields.access" :title="accessTitle" />
           </template>
+          <markdown-section :document="document" :field="fields.external_resources" />
           <div style="clear: both" />
         </div>
 
@@ -156,6 +157,10 @@ export default {
   computed: {
     capacityContext() {
       return this.document.waypoint_type === 'bivouac' ? this.document.waypoint_type : null;
+    },
+    showMainBox() {
+      const { summary, access_period, description, access, external_resources } = this.locale;
+      return summary || access_period || description || access || external_resources;
     },
   },
 };

--- a/src/views/wiki/edition/WaypointEditionView.vue
+++ b/src/views/wiki/edition/WaypointEditionView.vue
@@ -137,6 +137,13 @@
           :label="accessTitle"
         />
 
+        <form-field
+          class="is-12"
+          :document="document"
+          :field="fields.external_resources"
+          :placeholder="$gettext('Books and websites not already associated to this route')"
+        />
+
         <quality-field class="is-4" :document="document" />
       </div>
     </form-section>


### PR DESCRIPTION
https://github.com/c2corg/c2c_ui/issues/3697

Associated backend PR:  https://github.com/c2corg/v6_api/pull/1747

# How to test:

Pull the associated backend branch `feature/add-waypoints-external-resources`
Run the added migration using docker-compose exec api .build/venv/bin/alembic upgrade head
 
Create a new waypoint and fill the `external_resources` field. Then update the external resources of this.
 
 You should see something like this:
 
![Screenshot from 2024-02-18 11-03-40](https://github.com/c2corg/c2c_ui/assets/52289507/f0769fbe-d6d0-4987-b34e-e78146af1a2a)


![image](https://github.com/c2corg/c2c_ui/assets/52289507/07997101-0b3b-4908-b3da-84c9cc4c59e0)

 