### PR TITLE
fix: Avoid 'Network error' notification when opening c2c with expired token

### DIFF
--- a/src/js/apis/c2c/UserProfileService.js
+++ b/src/js/apis/c2c/UserProfileService.js
@@ -72,7 +72,22 @@ UserProfileService.prototype.login = function (username, password) {
   });
 };
 
-UserProfileService.prototype.logout = function () {
+UserProfileService.prototype.logout = function (token) {
+  // if the call is made on page load, and the user has expired token,
+  // the token will be passed as a parameter
+  if (token) {
+    this.api.axios
+      .post(
+        '/users/logout',
+        { discourse: true },
+        { headers: { common: { Authorization: 'JWT token="' + token + '"' } } }
+      )
+      .catch(() => {
+        // do nothing
+      });
+    return;
+  }
+
   return this.api.post('/users/logout', { discourse: true });
 };
 

--- a/src/js/apis/c2c/index.js
+++ b/src/js/apis/c2c/index.js
@@ -79,7 +79,7 @@ CamptocampApi.prototype.getRecentChanges = function (params) {
 /*
  * Upload images service
  */
-CamptocampApi.prototype.uploadImage = function (file, onUploadProgress, onSucess, onFailure) {
+CamptocampApi.prototype.uploadImage = function (file, onUploadProgress, onSuccess, onFailure) {
   const formData = new FormData();
 
   formData.append('file', file);
@@ -95,7 +95,7 @@ CamptocampApi.prototype.uploadImage = function (file, onUploadProgress, onSucess
   /* TODO : move this function in another service... */
   return this.axios
     .post(config.urls.imageBackend + '/upload', formData, requestConfig)
-    .then(onSucess)
+    .then(onSuccess)
     .catch(onFailure);
 };
 

--- a/src/js/vue-plugins/user.js
+++ b/src/js/vue-plugins/user.js
@@ -48,7 +48,6 @@ export default function install(Vue) {
     watch: {
       token: {
         handler: 'updateToken',
-        immediate: true,
       },
     },
 
@@ -74,7 +73,11 @@ export default function install(Vue) {
       },
 
       signout() {
-        c2c.userProfile.logout();
+        // we have an expired token in local storage, so we don't want to use that token
+        // for the API calls (we would go into https://github.com/c2corg/v6_api/issues/730 instead
+        // of doing unauthentified requests).
+        // We still want to make the logout call which needs a (potentially expired) token
+        c2c.userProfile.logout(this.token);
 
         this.token = null;
         this.roles = [];

--- a/src/views/Navigation.vue
+++ b/src/views/Navigation.vue
@@ -278,7 +278,7 @@ export default {
     },
 
     signout() {
-      this.$user.signout(this.$route);
+      this.$user.signout();
       if (this.$route.meta.requiresAuth) {
         this.$router.push({ name: 'home' });
       }


### PR DESCRIPTION
Currently if you have an expired token in your local cache:
- the expired token is retrieved
- a call to logout is done with the token
- data is also retrieved with the expired token
- then token is cleaned

This leads to the display of red notifications "Network error", because data is retrieved with an expired token

The current PR ensures that the calls are made unidentified (except the logout call)

I'm not completely happy with it, ideally we should be able to know if the displayed page requires auth or not, and in the first case, redirect to login page. Code is not great either, but imho it's less annoying than having the 'Network errors' displayed