### PR TITLE
Feat/#3936 add route transport information

### DIFF
--- a/src/components/cards/RouteCard.vue
+++ b/src/components/cards/RouteCard.vue
@@ -33,6 +33,7 @@
       <span class="card-icon">
         <!-- Englobing span is mandatory for tooltip ?? -->
         <marker-gps-trace v-if="document.geometry.has_geom_detail" />
+        <marker-soft-mobility v-if="$documentUtils.hasSoftMobility(document)" />
       </span>
 
       <span

--- a/src/components/cards/WaypointCard.vue
+++ b/src/components/cards/WaypointCard.vue
@@ -16,6 +16,8 @@
 
       <textual-array :array="document.slackline_types" i18n i18n-context="slackline_types" />
 
+      <marker-soft-mobility v-if="$documentUtils.hasSoftMobility(document)" />
+
       <marker-quality :quality="document.quality" />
     </card-row>
   </card-container>

--- a/src/js/constants/common.json
+++ b/src/js/constants/common.json
@@ -221,11 +221,12 @@
     "previous_injuries": ["no", "previous_injuries_2"],
     "product_types": ["farm_sale", "restaurant", "grocery", "bar", "sport_shop"],
     "public_transportation_ratings": [
-      "good service",
-      "seasonal service",
-      "poor service",
+      "no service",
+      "unknown service",
       "nearby service",
-      "no service"
+      "poor service",
+      "seasonal service",
+      "good service"
     ],
     "public_transportation_types": ["train", "bus", "service_on_demand", "boat"],
     "qualification": ["federal_supervisor", "federal_trainer", "professional_diploma"],

--- a/src/js/constants/documentsProperties.json
+++ b/src/js/constants/documentsProperties.json
@@ -462,6 +462,7 @@
       { "id": "mtb_length_trail", "properties": { "url": "mbtrack", "activities": ["mountain_biking"] } },
       { "id": "mtb_up_rating", "properties": { "url": "mbur", "activities": ["mountain_biking"] } },
       { "id": "orientations", "properties": { "url": "fac" } },
+      { "id": "public_transportation_rating" },
       { "id": "quality", "properties": { "url": "qa" } },
       {
         "id": "risk_rating",

--- a/src/js/constants/fieldsProperties.json
+++ b/src/js/constants/fieldsProperties.json
@@ -690,7 +690,8 @@
     "default": false
   },
   "public_transportation_rating": {
-    "values": "public_transportation_ratings"
+    "values": "public_transportation_ratings",
+    "default": "unknown service"
   },
   "public_transportation_types": {
     "values": "public_transportation_types",

--- a/src/js/vue-plugins/document-utils.js
+++ b/src/js/vue-plugins/document-utils.js
@@ -5,6 +5,7 @@
 
 import c2c from '@/js/apis/c2c';
 import constants from '@/js/constants';
+import common from '@/js/constants/common.json';
 
 // we need to use a VM, because we need access to Vue.$user.lang
 
@@ -373,6 +374,13 @@ export default function install(Vue) {
             return false;
           }
         }
+      },
+
+      hasSoftMobility(document) {
+        return (
+          document.public_transportation_rating &&
+          common.attributes.public_transportation_ratings.indexOf(document.public_transportation_rating) < 4
+        );
       },
 
       getDocumentsBbox(documents) {

--- a/src/translations/fixed_strings_common_js.vue
+++ b/src/translations/fixed_strings_common_js.vue
@@ -423,6 +423,7 @@
     <span v-translate translate-context="public_transportation_ratings">seasonal service</span>
     <span v-translate translate-context="public_transportation_ratings">poor service</span>
     <span v-translate translate-context="public_transportation_ratings">nearby service</span>
+    <span v-translate translate-context="public_transportation_ratings">unknown service</span>
     <span v-translate translate-context="public_transportation_ratings">no service</span>
     <!-- public_transportation_types -->
     <span v-translate translate-context="public_transportation_types">train</span>

--- a/src/views/document/RouteView.vue
+++ b/src/views/document/RouteView.vue
@@ -27,6 +27,7 @@
               <field-view :document="document" :field="fields.climbing_outdoor_type" />
               <field-view :document="document" :field="fields.configuration" />
               <field-view :document="document" :field="fields.slackline_type" />
+              <field-view :document="document" :field="fields.public_transportation_rating" />
             </div>
 
             <div class="column is-4">

--- a/src/views/document/utils/boxes/AssociatedDocuments.vue
+++ b/src/views/document/utils/boxes/AssociatedDocuments.vue
@@ -15,6 +15,7 @@
         </div>
         <div class="column is-paddingless">
           <document-title :document="waypoint" />
+          <marker-soft-mobility v-if="$documentUtils.hasSoftMobility(waypoint)" class="icon-link" />
         </div>
         <div class="column is-narrow has-text-grey is-paddingless is-size-7">{{ waypoint.elevation }}&nbsp;m</div>
       </document-link>


### PR DESCRIPTION
xref #3936

Display public transportation rating info (if available, computed by the backend with c2corg/v6_api#1067) on :
- routes header

Display a "bus" logo on:
- Waypoint cards
- Routes cards
- Waypoints association title