### PR TITLE
feat: add pictures in area

### DIFF
--- a/src/views/document/AreaView.vue
+++ b/src/views/document/AreaView.vue
@@ -27,7 +27,7 @@
           <div class="level is-mobile">
             <div
               class="level-item has-text-centered"
-              v-for="documentType of ['waypoint', 'route', 'outing']"
+              v-for="documentType of ['waypoint', 'image', 'route', 'outing']"
               :key="documentType"
             >
               <router-link :to="{ name: documentType + 's', query: { a: documentId } }" class="">


### PR DESCRIPTION
https://github.com/c2corg/c2c_ui/issues/3863

Adds the images link to an area just after the waypoints link (and before the routes link).

Some screenshots on a country and a local region page :  

![Capture](https://github.com/user-attachments/assets/3385b7c9-b486-40a5-8476-0a5b85d53118)

![Capture2](https://github.com/user-attachments/assets/e653aaa4-87ea-4bc2-9397-5da074f78904)