### PR TITLE
feat: clear search input on selection

### DIFF
--- a/src/views/Navigation.vue
+++ b/src/views/Navigation.vue
@@ -35,6 +35,7 @@
           :document-type="['waypoint', 'route', 'article', 'book']"
           propose-creation
           show-more-results-link
+          clear-input-on-toggle
           @input="go"
         />
 


### PR DESCRIPTION
Once clicking on an entry, we are redirected to that document. There is no reason the input should not be cleared.