### PR TITLE
fix: closing swipe gallery on back navigation and fix #4053

### DIFF
--- a/src/components/image-viewer/ImageViewer.vue
+++ b/src/components/image-viewer/ImageViewer.vue
@@ -164,8 +164,6 @@ export default {
         };
 
         this.$refs.swiper.addEventListener('init', () => {
-          window.history.pushState(null, null, '#swipe-gallery');
-
           // close when the user goes back in history
           window.addEventListener('popstate', this.close);
           // close on mouse wheel
@@ -213,12 +211,6 @@ export default {
         this.zt = null;
       }
       this.hideButtons = false;
-
-      // if we closed without hitting back, go back once in history
-      // to remove the hash
-      if (window.location.hash === '#swipe-gallery') {
-        window.history.back();
-      }
     },
 
     onKeydown(event) {

--- a/src/views/document/utils/document-view-mixin.js
+++ b/src/views/document/utils/document-view-mixin.js
@@ -222,7 +222,7 @@ export default {
     },
 
     handleRedirection() {
-      if (this.document.redirects_to) {
+      if (this.document?.redirects_to) {
         this.$router.push({ params: { id: this.document.redirects_to } });
       }
     },
@@ -265,6 +265,10 @@ export default {
     },
 
     updateUrl() {
+      if (!this.document) {
+        return;
+      }
+
       const currentPath = this.getCurrentPath();
       if (this.$route.path !== currentPath) {
         this.$router.replace(currentPath);


### PR DESCRIPTION
This solves #4053

The drawback is that it removes the functionality to close the gallery by navigating back, but I don't feel this is widely used nor a big issue.