### PR TITLE
fix: Prevent ads to overflow banner

### DIFF
--- a/src/views/DfmAdLarge.vue
+++ b/src/views/DfmAdLarge.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="camptocamp_htad" class="ams-ad is-flex is-justify-content-center" />
+  <div id="camptocamp_htad" class="ams-ad is-flex is-justify-content-center is-clipped" />
 </template>
 
 <script>


### PR DESCRIPTION
There is a bug right now: ad is overflowing the banner, making some parts of the website inaccessible