### PR TITLE
fix: c2org#4082 merged doc redirect to bad url

### DIFF
--- a/src/views/document/utils/document-view-mixin.js
+++ b/src/views/document/utils/document-view-mixin.js
@@ -144,7 +144,7 @@ export default {
     },
 
     lang() {
-      return this.document?.cooked?.lang;
+      return this.document?.cooked?.lang ?? this.$language.current;
     },
   },
 


### PR DESCRIPTION
## Issue
#4082 
## Resolution
The issue is `this.document?.cooked?.lang` is undefined when we try the redirection. Also, when the user switch language, the page language change but not URL. That's why i choose to use `this.$language.current`.

ps: I kept `this.document?.cooked?.lang` because it works for others articles and since there is no test, i think it's better to keep it like this to avoid regression