### PR TITLE
fix: Correctly parse IPTC date if time is provided

### DIFF
--- a/src/js/upload-file.js
+++ b/src/js/upload-file.js
@@ -34,7 +34,7 @@ const parseDate = (exif, iptc) => {
 
   if (iptcDate) {
     if (iptc?.TimeCreated) {
-      date = dayjs(`${iptcDate}T${iptc.TimeCreated}`);
+      date = dayjs(`${iptcDate}T${iptc.TimeCreated}`, 'YYYYMMDDThhmmssZZ');
     } else {
       date = dayjs(iptcDate, 'YYYYMMDD');
     }


### PR DESCRIPTION
The image in issue #4254 contains both exif and iptc date.

Exif:
DateTimeOriginal => "2025:03:07 15:41:42"
DateTimeDigitized => "2024:03:07 15:41:42"

Iptc:
DateCreated => "20250307"
TimeCreated => "154142+0100"

The code tries to parse a concatenation of both iptc fields (separated by T) first, but the format is not provided to dayjs, and is not a valid iso8601, which results in an invalid date, and thus the creation time of the image is not extracted.

The PR adds the expected format, so that this is properly parsed


Fixes #4254 
