### PR TITLE
feat: Initialization CPS 2025

### DIFF
--- a/src/views/portals/SophiePictureContestView.vue
+++ b/src/views/portals/SophiePictureContestView.vue
@@ -513,6 +513,10 @@ export default {
         },
       ],
     },
+    2025: {
+      year: 2025,
+      documentId: 1809682,
+    },
   },
 
   computed: {


### PR DESCRIPTION
Add CPS 2025 in the list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 2025 to the year selector in the Sophie Picture Contest, enabling navigation and data loading for that year.
  * Candidate and history views are now accessible for 2025, behaving consistently with previous years.
  * The winners section is currently not shown for 2025 and will appear automatically once results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->