### PR TITLE
feat: add ad cookies for GDPR

### DIFF
--- a/src/components/gdpr/GdprModal.vue
+++ b/src/components/gdpr/GdprModal.vue
@@ -27,8 +27,6 @@
           a form or define your cookie preferences. If you configure your computer to block these cookies or to warn you
           of their existence, our website will not function fully.
         </p>
-      </div>
-      <div class="column">
         <div class="is-flex is-justify-content-space-between is-align-items-baseline">
           <h2 class="is-size-3" v-translate>Statistical cookies</h2>
           <div class="field">
@@ -46,6 +44,20 @@
           Thanks to the statistical cookies provided by ourselves and other companies, we can evaluate the visit on our
           website and know the sources of traffic. Data we obtain help us understand what visitors like and improve our
           website. If you reject them, we cannot improve your experience.
+        </p>
+      </div>
+      <div class="column">
+        <div class="is-flex is-justify-content-space-between is-align-items-baseline">
+          <h2 class="is-size-3" v-translate>Advertisement cookies</h2>
+          <div class="field">
+            <input type="checkbox" id="ad" name="ad" class="switch is-rounded" v-model="gdpr.ad" />
+            <label for="ad"></label>
+          </div>
+        </div>
+        <p v-translate>
+          These cookies are used to provide you with personalized advertising based on your browsing on the site. They
+          track your activities on the site in order to display relevant ads tailored to your interests. By disabling
+          these cookies, you will continue to see ads, but they will no longer be tailored to your preferences.
         </p>
         <div class="is-flex is-justify-content-space-between is-align-items-baseline">
           <h2 class="is-size-3" v-translate>Social cookies</h2>

--- a/src/js/vue-plugins/gdpr.js
+++ b/src/js/vue-plugins/gdpr.js
@@ -41,7 +41,9 @@ export default function install(Vue) {
       },
 
       setAll(accept) {
-        this.set(accept ? { statistics: true, social: true } : { statistics: false, social: false });
+        this.set(
+          accept ? { statistics: true, social: true, ad: true } : { statistics: false, social: false, ad: false }
+        );
       },
     },
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Advertisement cookies preference section to GDPR consent modal, enabling users to independently manage personalized advertising consent alongside existing statistical and social media cookie options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->