### PR TITLE
feat: CPS 2025 jury prize

### DIFF
--- a/src/views/portals/SophiePictureContestView.vue
+++ b/src/views/portals/SophiePictureContestView.vue
@@ -518,7 +518,7 @@ export default {
       documentId: 1809682,
       winners: [
         {
-          title: 'Rappel de l'Ermite',
+          title: "Rappel de l'Ermite",
           author: 'Emilien Hugon',
           image: { document_id: 1820998 },
           category: 'Action',


### PR DESCRIPTION
Add jury prize (action, paysage, faune/flore/inclassable/topoguide) for 2025 edition of CPS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published the 2025 Sophie Picture Contest winners: four winning photographs are now shown with their titles, artist names and award categories (Action, Landscape, Fauna/Flora/Inclassable, Topoguide). These entries are visible within the contest view so visitors can browse the winning images and associated details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->