### PR TITLE
feat: add geo: URI link on document map box

### DIFF
--- a/src/views/document/utils/boxes/MapBox.vue
+++ b/src/views/document/utils/boxes/MapBox.vue
@@ -39,6 +39,14 @@
     </div>
 
     <div class="buttons is-centered">
+      <a
+        v-if="geoUri && $screen.isMobile"
+        :href="geoUri"
+        class="button is-primary is-small"
+        :title="$gettext('Open this location in your map app')"
+      >
+        <fa-icon icon="map-marker-alt" />
+      </a>
       <button v-if="showDownloadTraceButtons" class="button is-primary is-small" @click="downloadGpx">GPX</button>
       <button v-if="showDownloadTraceButtons" class="button is-primary is-small" @click="downloadKml">KML</button>
       <button
@@ -93,6 +101,23 @@ export default {
 
     hasMapLinks() {
       return (this.document.maps && this.document.maps.length !== 0) || this.document.maps_info;
+    },
+
+    geoUri() {
+      if (!this.document.geometry || !this.document.geometry.geom) {
+        return null;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(this.document.geometry.geom);
+      } catch {
+        return null;
+      }
+      if (parsed.type !== 'Point' || !Array.isArray(parsed.coordinates)) {
+        return null;
+      }
+      const [lon, lat] = ol.proj.toLonLat(parsed.coordinates);
+      return `geo:${lat.toFixed(6)},${lon.toFixed(6)}?q=${lat.toFixed(6)},${lon.toFixed(6)}`;
     },
   },
 


### PR DESCRIPTION
## What

Adds a button next to the GPX/KML download buttons on the document map box. On mobile, tapping it opens the document's location in the user's preferred map app (Google Maps, OsmAnd, Maps.me, Organic Maps, Plans, etc.) via a `geo:` URI ([RFC 5870](https://datatracker.ietf.org/doc/html/rfc5870)).

## Why

Requested on the forum by community members: https://forum.camptocamp.org/t/application-camptocamp-cahier-des-charges-a-elaborer-avec-vous/308792

Currently, to navigate to a waypoint or trailhead from camptocamp.org on a phone, users have to copy coordinates manually or download the GPX and import it elsewhere. This adds a one-tap path that integrates with whatever map app the user already uses.

## Scope

- One file modified: `src/views/document/utils/boxes/MapBox.vue`
- ~25 lines added, no dependencies, no API changes
- Button only renders on mobile (`$screen.isMobile`) and only when the document has a Point geometry
- Falls back gracefully (returns `null`, button is hidden) if geometry is missing or malformed
- Uses `ol.proj.toLonLat` to convert from the internal EPSG:3857 projection to WGS84 expected by the `geo:` URI scheme

## How to test

1. `npm run serve`
2. Open DevTools, toggle device toolbar (`Ctrl+Shift+M`), pick a mobile device profile
3. Navigate to any waypoint, e.g. http://localhost:8080/waypoints
4. The new pin icon appears next to the GPX / KML buttons under the map
5. Inspect the `<a>` element — the `href` is `geo:LAT,LON?q=LAT,LON` with 6-decimal precision (≈10 cm)
6. On a real mobile device, tapping the button opens the OS's "Open with..." dialog with installed map apps

## Notes

The `geo:` URI scheme has no handler on desktop browsers — the button is intentionally hidden there (`v-if="... && $screen.isMobile"`) to keep the UI clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile users can now open location data directly in their device's default map application via a new "Open this location in your map app" button, available when location information is present.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/c2corg/c2c_ui/pull/4565)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->