### PR TITLE
fix: absence of search_lang param in search

### DIFF
--- a/src/components/association-editor/AssociationsWindow.vue
+++ b/src/components/association-editor/AssociationsWindow.vue
@@ -105,7 +105,15 @@ export default {
       const text = event.target.value;
 
       if (text.length >= 3) {
-        c2c.search({ q: text, t: this.letterTypes.join(','), limit: 5 }).then(this.computePropositions);
+        c2c
+          .search({
+            q: text,
+            t: this.letterTypes.join(','),
+            limit: 5,
+            l: this.$language.current,
+            pl: this.$language.current,
+          })
+          .then(this.computePropositions);
       }
     },
 

--- a/src/components/generics/inputs/InputDocument.vue
+++ b/src/components/generics/inputs/InputDocument.vue
@@ -209,6 +209,8 @@ export default {
           q: this.searchText,
           t: this.letterTypes.join(','),
           limit: 7,
+          l: this.$language.current,
+          pl: this.$language.current,
         })
         .then((response) => {
           response.data.profiles = response.data.users;


### PR DESCRIPTION
it helps the elasticsearch to match documents in the user's current language

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document search results by sending the current language context with search requests.
* **Refactor**
  * Updated a search call to a clearer multi-line format without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->