### PR TITLE
feat: more visible & customizable fundraiser message (#4563)

### DIFF
--- a/src/js/get-fundraiser.js
+++ b/src/js/get-fundraiser.js
@@ -1,3 +1,10 @@
+// Identity marker so fundraiser `message` strings get extracted to the .pot file
+// by tools/extract-messages.js. The actual translation is done at render time via
+// the component's `this.$gettext()`. To add a localized message to an entry, just
+// add a `message: $gettext('Your English message')` field; translations are then
+// managed in Transifex.
+const $gettext = (msgid) => msgid;
+
 const mapping = {
   // France
   // 14274: { // FFME - Rockclimber
@@ -7,6 +14,7 @@ const mapping = {
   // Buoux
   102357: {
     url: 'https://www.aptitudes-escalade.com/i-love-buoux/',
+    message: $gettext('Buoux is maintained by local volunteers. Help keep it bolted and open!'),
   },
 
   // Roche de Narse

--- a/src/views/document/AreaView.vue
+++ b/src/views/document/AreaView.vue
@@ -23,6 +23,8 @@
           <div style="clear: both" />
         </div>
 
+        <fundraiser-banner :document="document" />
+
         <div class="box no-print">
           <div class="level is-mobile">
             <div

--- a/src/views/document/RouteView.vue
+++ b/src/views/document/RouteView.vue
@@ -108,6 +108,8 @@
             </div>
           </markdown-section>
 
+          <fundraiser-banner :document="document" />
+
           <markdown-section :document="document" :field="fields.gear">
             <div class="content automatic-gears" slot="after" v-if="Object.keys(gearArticles).length !== 0">
               <ul>

--- a/src/views/document/WaypointView.vue
+++ b/src/views/document/WaypointView.vue
@@ -130,6 +130,8 @@
           <div style="clear: both" />
         </div>
 
+        <fundraiser-banner :document="document" />
+
         <routes-box v-if="!isDraftView && document.waypoint_type !== 'climbing_indoor'" :document="document" />
         <recent-outings-box v-if="!isDraftView" :document="document" />
         <images-box v-if="!isDraftView" :document="document" />

--- a/src/views/document/utils/FundraiserBanner.vue
+++ b/src/views/document/utils/FundraiserBanner.vue
@@ -1,0 +1,50 @@
+<template>
+  <div v-if="fundraiser" class="notification is-info is-light no-print fundraiser-banner">
+    <fa-icon :icon="['miscs', 'drill']" class="fundraiser-icon has-text-danger" fixed-width />
+    <span class="fundraiser-message">{{ message }}</span>
+    <a :href="fundraiser.url" target="_blank" rel="noopener" class="button is-small is-info">
+      <span v-translate>Contribute to maintainance</span>
+    </a>
+  </div>
+</template>
+
+<script>
+import getFundraiser from '@/js/get-fundraiser';
+
+export default {
+  props: {
+    document: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  computed: {
+    fundraiser() {
+      return getFundraiser(this.document);
+    },
+
+    message() {
+      return this.fundraiser?.message
+        ? this.$gettext(this.fundraiser.message)
+        : this.$gettext('This site is maintained by local actors. Support them to help keep it open!');
+    },
+  },
+};
+</script>
+
+<style scoped>
+.fundraiser-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.fundraiser-icon {
+  font-size: 1.5rem;
+}
+
+.fundraiser-message {
+  flex: 1;
+}
+</style>

--- a/src/views/document/utils/document-view-mixin.js
+++ b/src/views/document/utils/document-view-mixin.js
@@ -1,5 +1,6 @@
 import DocumentPrintLicense from './DocumentPrintLicense';
 import DocumentViewHeader from './DocumentViewHeader';
+import FundraiserBanner from './FundraiserBanner';
 import CommentsBox from './boxes/CommentsBox';
 import ImagesBox from './boxes/ImagesBox';
 import IsReachableByPublicTransportsBox from './boxes/IsReachableByPublicTransportsBox';
@@ -27,6 +28,7 @@ import viewModeMixin from '@/js/view-mode-mixin';
 export default {
   components: {
     DocumentViewHeader,
+    FundraiserBanner,
 
     CommentsBox,
     DocumentPrintLicense,


### PR DESCRIPTION
- Add optional translatable `message` field to get-fundraiser.js entries (extracted to Transifex via a local $gettext marker; Buoux as example).
- New FundraiserBanner.vue: prominent notification with drill icon, the customizable message (or a default) and a 'Contribute' link.
- Render the banner at the end of remarks/description in Route, Waypoint and Area views; keep the existing ToolBox drill button.